### PR TITLE
specify all asJSON method match.arg choices args

### DIFF
--- a/R/asJSON.Date.R
+++ b/R/asJSON.Date.R
@@ -1,7 +1,7 @@
 setMethod("asJSON", "Date", function(x, Date = c("ISO8601", "epoch"), ...) {
 
   # Validate argument
-  Date <- match.arg(Date)
+  Date <- match.arg(Date, choices = c("ISO8601", "epoch"))
 
   # select a schema
   output <- switch(Date,

--- a/R/asJSON.POSIXt.R
+++ b/R/asJSON.POSIXt.R
@@ -4,7 +4,7 @@ setMethod("asJSON", "POSIXt", function(x, POSIXt = c("string", "ISO8601", "epoch
   # instead of ?as.character
 
   # Validate
-  POSIXt <- match.arg(POSIXt)
+  POSIXt <- match.arg(POSIXt, choices = c("string", "ISO8601", "epoch", "mongo"))
 
   # Encode based on a schema
   if (POSIXt == "mongo") {

--- a/R/asJSON.array.R
+++ b/R/asJSON.array.R
@@ -3,7 +3,7 @@ setMethod("asJSON", "array", function(x, collapse = TRUE, na = NULL, oldna = NUL
   indent = NA_integer_, ...) {
 
   #validate
-  matrix <- match.arg(matrix);
+  matrix <- match.arg(matrix, choices = c("rowmajor", "columnmajor"));
 
   # reset na arg when called from data frame
   if(identical(na, "NA")){

--- a/R/asJSON.character.R
+++ b/R/asJSON.character.R
@@ -19,7 +19,7 @@ setMethod("asJSON", "character", function(x, collapse = TRUE, na = c("null", "st
 
   # validate NA
   if (any(missings <- which(is.na(x)))) {
-    na <- match.arg(na)
+    na <- match.arg(na, choices = c("null", "string", "NA"))
     if (na %in% c("null")) {
       tmp[missings] <- "null"
     } else if(na %in% "string") {

--- a/R/asJSON.complex.R
+++ b/R/asJSON.complex.R
@@ -2,7 +2,7 @@ setMethod("asJSON", "complex", function(x, digits = 5, collapse = TRUE, complex 
   "list"), na = c("string", "null", "NA"), oldna = NULL, ...) {
 
   # validate
-  na <- match.arg(na);
+  na <- match.arg(na, choices = c("string", "null", "NA"));
   complex <- match.arg(complex)
 
   #turn into strings

--- a/R/asJSON.data.frame.R
+++ b/R/asJSON.data.frame.R
@@ -8,7 +8,7 @@ setMethod("asJSON", "data.frame", function(x, na = c("NA", "null", "string"), co
   }
 
   # Validate some args
-  dataframe <- match.arg(dataframe)
+  dataframe <- match.arg(dataframe, choices = c("rows", "columns", "values"))
   has_names <- identical(length(names(x)), ncol(x))
 
   # Default to adding row names only if they are strings and not just stringified numbers
@@ -47,7 +47,7 @@ setMethod("asJSON", "data.frame", function(x, na = c("NA", "null", "string"), co
 
   # Set default for row based, don't do it earlier because it will affect 'oldna' or dataframe="columns"
   if(dataframe == "rows" && has_names){
-    na <- match.arg(na)
+    na <- match.arg(na, choices = c("NA", "null", "string"))
   }
 
   # no records

--- a/R/asJSON.factor.R
+++ b/R/asJSON.factor.R
@@ -1,6 +1,6 @@
 setMethod("asJSON", "factor", function(x, factor = c("string", "integer"), keep_vec_names = FALSE, ...) {
   # validate
-  factor <- match.arg(factor)
+  factor <- match.arg(factor, choices = c("string", "integer"))
 
   # dispatch
   if (factor == "integer") {

--- a/R/asJSON.function.R
+++ b/R/asJSON.function.R
@@ -1,11 +1,11 @@
-setMethod("asJSON", "function", function(x, collapse = TRUE, fun = c("source", "list"), 
+setMethod("asJSON", "function", function(x, collapse = TRUE, fun = c("source", "list"),
   ...) {
   # validate
-  fun <- match.arg(fun)
-  
+  fun <- match.arg(fun, choices = c("source", "list"))
+
   if (fun == "source") {
     return(asJSON(deparse(x), ...))
   } else {
     return(asJSON(as.list(x), ...))
   }
-}) 
+})

--- a/R/asJSON.logical.R
+++ b/R/asJSON.logical.R
@@ -8,7 +8,7 @@ setMethod("asJSON", "logical", function(x, collapse = TRUE, na = c("null", "stri
   }
 
   # validate arg
-  na <- match.arg(na)
+  na <- match.arg(na, choices = c("null", "string", "NA"))
 
   # json true/false
   tmp <- ifelse(x, "true", "false")

--- a/R/asJSON.numeric.R
+++ b/R/asJSON.numeric.R
@@ -9,7 +9,7 @@ setMethod("asJSON", "numeric", function(x, digits = 5, use_signif = is(digits, "
       auto_unbox = TRUE, collapse = collapse, ...))
   }
 
-  na <- match.arg(na);
+  na <- match.arg(na, choices = c("string", "null", "NA"));
   na_as_string <- switch(na,
     "string" = TRUE,
     "null" = FALSE,

--- a/R/asJSON.raw.R
+++ b/R/asJSON.raw.R
@@ -1,7 +1,7 @@
 setMethod("asJSON", "raw", function(x, raw = c("base64", "hex", "mongo"), ...) {
 
   # validate
-  raw <- match.arg(raw)
+  raw <- match.arg(raw, choices = c("base64", "hex", "mongo"))
 
   # encode based on schema
   if (raw == "mongo") {


### PR DESCRIPTION
- looking up the default arg is slow
- for example in this call:
  
  system.time(j<-toJSON(matrix(1L, ncol=3, nrow=50000)))
  
  20% of the execution time is spent in match.arg on my system
- since asJSON is not exported or documented, there seems no strong 
  convenience advantage to offset this performance penalty.
