### PR TITLE
Add escape_solidus option

### DIFF
--- a/R/asJSON.character.R
+++ b/R/asJSON.character.R
@@ -1,21 +1,14 @@
 setMethod("asJSON", "character", function(x, collapse = TRUE, na = c("null", "string", "NA"),
-  auto_unbox = FALSE, keep_vec_names = FALSE, indent = NA_integer_, ...) {
+  auto_unbox = FALSE, keep_vec_names = FALSE, escape_solidus = FALSE, indent = NA_integer_, ...) {
 
   # shiny legacy exception
   if(isTRUE(keep_vec_names) && length(names(x))){
     warn_keep_vec_names()
-    return(asJSON(as.list(x), na = na, auto_unbox = TRUE, collapse = collapse, ...))
+    return(asJSON(as.list(x), na = na, auto_unbox = TRUE, collapse = collapse, escape_solidus = escape_solidus, ...))
   }
 
   # vectorized escaping
-  tmp <- deparse_vector(x)
-
-  # this was used with deparse_vector_old
-  #if(identical(Encoding(x), "UTF-8")){
-  #  if(!grepl("UTF", Sys.getlocale("LC_CTYPE"), ignore.case=TRUE)){
-  #    tmp <- utf8conv(tmp);
-  #  }
-  #}
+  tmp <- deparse_vector(x, escape_solidus)
 
   # validate NA
   if (any(missings <- which(is.na(x)))) {

--- a/R/asJSON.data.frame.R
+++ b/R/asJSON.data.frame.R
@@ -1,6 +1,6 @@
 setMethod("asJSON", "data.frame", function(x, na = c("NA", "null", "string"), collapse = TRUE,
   dataframe = c("rows", "columns", "values"), complex = "string", oldna = NULL, rownames = NULL,
-  keep_vec_names = FALSE, indent = NA_integer_, ...) {
+  keep_vec_names = FALSE, escape_solidus = FALSE, indent = NA_integer_, ...) {
 
   # Coerse pairlist if needed
   if (is.pairlist(x)) {
@@ -35,7 +35,7 @@ setMethod("asJSON", "data.frame", function(x, na = c("NA", "null", "string"), co
   # Column based is same as list. Do not pass collapse arg because it is a named list.
   if (dataframe == "columns") {
     return(asJSON(as.list(x), is_df = TRUE, na = na, dataframe = dataframe,
-      complex = complex, rownames = rownames, indent = indent, ...))
+      complex = complex, rownames = rownames, indent = indent, escape_solidus = escape_solidus, ...))
   }
 
   # Determine "oldna". This is needed when the data frame contains a list column
@@ -70,10 +70,10 @@ setMethod("asJSON", "data.frame", function(x, na = c("NA", "null", "string"), co
   }
 
   #create a matrix of json elements
-  dfnames <- deparse_vector(cleannames(names(x)))
+  dfnames <- deparse_vector(cleannames(names(x)), escape_solidus)
   out <- vapply(x, asJSON, character(nrow(x)), collapse=FALSE, complex = complex, na = na,
     oldna = oldna, rownames = rownames, dataframe = dataframe, indent = indent + 2L,
-    ..., USE.NAMES = FALSE)
+    escape_solidus = escape_solidus, ..., USE.NAMES = FALSE)
 
   # This would be another way of doing the missing values
   # This does not require the individual classes to support na="NA"

--- a/R/asJSON.list.R
+++ b/R/asJSON.list.R
@@ -1,5 +1,5 @@
 setMethod("asJSON", "list", function(x, collapse = TRUE, na = NULL, oldna = NULL,
-  is_df = FALSE, auto_unbox = FALSE, indent = NA_integer_, ...) {
+  is_df = FALSE, auto_unbox = FALSE, escape_solidus = FALSE, indent = NA_integer_, ...) {
 
   # reset na arg when called from data frame
   if(identical(na, "NA")){
@@ -30,9 +30,9 @@ setMethod("asJSON", "list", function(x, collapse = TRUE, na = NULL, oldna = NULL
   tmp <- if(is_df && auto_unbox){
     vapply(x, function(y, ...) {
       asJSON(y, auto_unbox = is.list(y), ...)
-    }, character(1), na = na, indent = indent + 2L, ...)
+    }, character(1), na = na, escape_solidus = escape_solidus, indent = indent + 2L, ...)
   } else {
-    vapply(x, asJSON, character(1), na = na, auto_unbox = auto_unbox, indent = indent + 2L, ...)
+    vapply(x, asJSON, character(1), na = na, auto_unbox = auto_unbox, escape_solidus = escape_solidus, indent = indent + 2L, ...)
   }
 
   if (!is.null(names(x))) {
@@ -41,7 +41,7 @@ setMethod("asJSON", "list", function(x, collapse = TRUE, na = NULL, oldna = NULL
       warning("collapse=FALSE called for named list.")
     }
     #in case of named list:
-    objnames <- deparse_vector(cleannames(names(x)))
+    objnames <- deparse_vector(cleannames(names(x)), escape_solidus)
     collapse_object(objnames, tmp, indent)
   } else {
     #in case of unnamed list:

--- a/R/deparse_vector.R
+++ b/R/deparse_vector.R
@@ -1,27 +1,4 @@
 #' @useDynLib jsonlite C_escape_chars
-deparse_vector_c <- function(x) {
-  .Call(C_escape_chars, x)
-}
-
-deparse_vector_r <- function(x) {
-  stopifnot(is.character(x))
-  if(!length(x)) return(x)
-  x <- gsub("\\", "\\\\", x, fixed=TRUE)
-  x <- gsub("\"", "\\\"", x, fixed=TRUE)
-  x <- gsub("\n", "\\n", x, fixed=TRUE)
-  x <- gsub("\r", "\\r", x, fixed=TRUE)
-  x <- gsub("\t", "\\t", x, fixed=TRUE)
-  x <- gsub("\b", "\\b", x, fixed=TRUE)
-  x <- gsub("\f", "\\f", x, fixed=TRUE)
-  paste0("\"", x, "\"")
-}
-
-# Which implementation to use
-deparse_vector <- deparse_vector_c
-
-#Below are older implementations of the same function
-deparse_vector_old <- function(x) {
-  stopifnot(is.character(x))
-  x <- gsub("[\v\a]", "", x)
-  vapply(x, deparse, character(1), USE.NAMES=FALSE)
+deparse_vector <- function(x, escape_solidus = FALSE) {
+  .Call(C_escape_chars, x, escape_solidus)
 }

--- a/tests/testthat/helper-toJSON.R
+++ b/tests/testthat/helper-toJSON.R
@@ -1,5 +1,5 @@
 toJSON <- function(...){
-  unclass(minify(jsonlite::toJSON(...)))
+  unclass(jsonlite::toJSON(...))
 }
 
 toJSON2 <- function(x) {

--- a/tests/testthat/test-toJSON-solidus.R
+++ b/tests/testthat/test-toJSON-solidus.R
@@ -1,0 +1,20 @@
+context("toJSON escape solidus")
+
+test_that("Solidus is escaped properly", {
+  script <- list("foo/bar" = "<script>evil()</script>")
+  json <- toJSON(script)
+  json_safe <- toJSON(script, escape_solidus = TRUE)
+  expect_equal(json, '{"foo/bar":["<script>evil()</script>"]}')
+  expect_equal(json_safe, '{"foo\\/bar":["<script>evil()<\\/script>"]}')
+  expect_identical(fromJSON(json), fromJSON(json_safe))
+
+  # check for data frames and factors
+  df <- data.frame(x = pi)
+  df[["a/b/c"]] = "<script>evil()</script>"
+  df[["script"]] = script
+  json <- toJSON(df)
+  json_safe <- toJSON(df, escape_solidus = TRUE)
+  expect_equal(json, '[{"x":3.1416,"a/b/c":"<script>evil()</script>","script":["<script>evil()</script>"]}]')
+  expect_equal(json_safe, '[{"x":3.1416,"a\\/b\\/c":"<script>evil()<\\/script>","script":["<script>evil()<\\/script>"]}]')
+  expect_identical(fromJSON(json), fromJSON(json_safe))
+})


### PR DESCRIPTION
Fixes https://github.com/jeroenooms/jsonlite/issues/163 by adding an option `escape_solidus = TRUE` to escape the forward slashes. @wch could you review this code and test if it solves your problem?