### PR TITLE
Added documentation and explicit argument for `use_signif` 

### DIFF
--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -37,6 +37,7 @@
 #' @param auto_unbox automatically \code{\link{unbox}} all atomic vectors of length 1. It is usually safer to avoid this and instead use the \code{\link{unbox}} function to unbox individual elements.
 #'   An exception is that objects of class \code{AsIs} (i.e. wrapped in \code{I()}) are not automatically unboxed. This is a way to mark single values as length-1 arrays.
 #' @param digits max number of decimal digits to print for numeric values. Use \code{I()} to specify significant digits. Use \code{NA} for max precision.
+#' @param use_signif Specify that significant digits should be used. Overides whether digits param is AsIs.
 #' @param force unclass/skip objects of classes with no defined JSON mapping
 #' @param pretty adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}
 #' @param ... arguments passed on to class specific \code{print} methods
@@ -122,4 +123,3 @@ fromJSON_string <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simp
     return(obj)
   }
 }
-

--- a/R/toJSON.R
+++ b/R/toJSON.R
@@ -3,7 +3,7 @@ toJSON <- function(x, dataframe = c("rows", "columns", "values"), matrix = c("ro
   Date = c("ISO8601", "epoch"), POSIXt = c("string", "ISO8601", "epoch", "mongo"),
   factor = c("string", "integer"), complex = c("string", "list"), raw = c("base64", "hex", "mongo"),
   null = c("list", "null"), na = c("null", "string"), auto_unbox = FALSE, digits = 4,
-  pretty = FALSE, force = FALSE, ...) {
+  use_signif = is(digits, "AsIs"), pretty = FALSE, force = FALSE, ...) {
 
   # validate args
   dataframe <- match.arg(dataframe)
@@ -30,7 +30,7 @@ toJSON <- function(x, dataframe = c("rows", "columns", "values"), matrix = c("ro
   # dispatch
   ans <- asJSON(x, dataframe = dataframe, Date = Date, POSIXt = POSIXt, factor = factor,
     complex = complex, raw = raw, matrix = matrix, auto_unbox = auto_unbox, digits = digits,
-    na = na, null = null, force = force, indent = indent, ...)
+    use_signif = use_signif, na = na, null = null, force = force, indent = indent, ...)
 
   #prettify with yajl
   if(is.numeric(pretty)) {

--- a/man/fromJSON.Rd
+++ b/man/fromJSON.Rd
@@ -16,7 +16,8 @@ toJSON(x, dataframe = c("rows", "columns", "values"), matrix = c("rowmajor",
   "ISO8601", "epoch", "mongo"), factor = c("string", "integer"),
   complex = c("string", "list"), raw = c("base64", "hex", "mongo"),
   null = c("list", "null"), na = c("null", "string"), auto_unbox = FALSE,
-  digits = 4, pretty = FALSE, force = FALSE, ...)
+  digits = 4, use_signif = is(digits, "AsIs"), pretty = FALSE,
+  force = FALSE, ...)
 }
 \arguments{
 \item{txt}{a JSON string, URL or file}
@@ -55,6 +56,8 @@ toJSON(x, dataframe = c("rows", "columns", "values"), matrix = c("rowmajor",
 An exception is that objects of class \code{AsIs} (i.e. wrapped in \code{I()}) are not automatically unboxed. This is a way to mark single values as length-1 arrays.}
 
 \item{digits}{max number of decimal digits to print for numeric values. Use \code{I()} to specify significant digits. Use \code{NA} for max precision.}
+
+\item{use_signif}{Specify that significant digits should be used. Overides whether digits param is AsIs.}
 
 \item{pretty}{adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}}
 

--- a/tests/testthat/test-toJSON-numeric.R
+++ b/tests/testthat/test-toJSON-numeric.R
@@ -46,3 +46,13 @@ test_that("Force decimal works", {
   y2 <- fromJSON(toJSON(x1, digits = 9, always_decimal = TRUE), simplifyVector = FALSE)
   expect_identical(as.list(x1), y2)
 })
+
+test_that("Usnig significant digits", {
+  numbers <- rnorm(10)
+  digits <- sample(1:10, 1)
+  expect_equal(toJSON(numbers, digits=I(digits)), toJSON(numbers, digits=digits, use_signif=TRUE))
+
+  expect_equal(toJSON(1.2345, use_signif=TRUE, digits=4), "[1.234]")
+  expect_equal(toJSON(123456, use_signif=TRUE, digits=4), "[1.235e+05]")
+  expect_equal(toJSON(1.234e-5, use_signif=TRUE, digits=4), "[1.234e-05]")
+})


### PR DESCRIPTION
Hi!

After learning about the argument `use_signif` in #184, I saw this was something commonly mentioned as a solution to issues (#166, #158, #144, #148). I think having this argument be easier to find by documenting it would be a positive thing.

I've added a test for usage of this argument. While I was at it, I noticed there weren't any tests for significant digits so I added a few.

This is my first time opening a pull request to an R package, so I'm very open to feedback.