### PR TITLE
Add asJSON for difftime

### DIFF
--- a/R/asJSON.difftime.R
+++ b/R/asJSON.difftime.R
@@ -1,0 +1,27 @@
+setMethod("asJSON", "difftime", function(x, difftime = c("string", "epoch"), always_decimal = FALSE, ...) {
+
+  # Validate argument
+  difftime <- match.arg(difftime)
+
+  # select a schema
+  output <- switch(difftime,
+                   string = format(x),
+                   epoch = {
+                     value <- unclass(x)
+                     units <- attr(x, "units")
+                     if (units == "secs"){
+                       values <- value[1]
+                     } else if(units == "mins") {
+                       value <- value[1] * 60
+                     } else if(units == "hours") {
+                       value <- value[1] * 3600
+                     } else if(units == "days") {
+                       value <- value[1] * 86400
+                     }
+                   },
+                   default = stop("Invalid argument for 'difftime':", difftime)
+  )
+
+  # Dispatch to character encoding
+  asJSON(output, always_decimal = FALSE, ...)
+})

--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -29,6 +29,7 @@
 #' @param matrix how to encode matrices and higher dimensional arrays: must be one of 'rowmajor' or 'columnmajor'.
 #' @param Date how to encode Date objects: must be one of 'ISO8601' or 'epoch'
 #' @param POSIXt how to encode POSIXt (datetime) objects: must be one of 'string', 'ISO8601', 'epoch' or 'mongo'
+#' @param difftime how to encode difftime objects: must be either 'string' or 'epoch'
 #' @param factor how to encode factor objects: must be one of 'string' or 'integer'
 #' @param complex how to encode complex numbers: must be one of 'string' or 'list'
 #' @param raw how to encode raw objects: must be one of 'base64', 'hex' or 'mongo'

--- a/R/toJSON.R
+++ b/R/toJSON.R
@@ -1,6 +1,6 @@
 #' @rdname fromJSON
 toJSON <- function(x, dataframe = c("rows", "columns", "values"), matrix = c("rowmajor", "columnmajor"),
-  Date = c("ISO8601", "epoch"), POSIXt = c("string", "ISO8601", "epoch", "mongo"),
+  Date = c("ISO8601", "epoch"), POSIXt = c("string", "ISO8601", "epoch", "mongo"), difftime = c("string", "epoch"),
   factor = c("string", "integer"), complex = c("string", "list"), raw = c("base64", "hex", "mongo"),
   null = c("list", "null"), na = c("null", "string"), auto_unbox = FALSE, digits = 4,
   pretty = FALSE, force = FALSE, ...) {
@@ -10,6 +10,7 @@ toJSON <- function(x, dataframe = c("rows", "columns", "values"), matrix = c("ro
   matrix <- match.arg(matrix)
   Date <- match.arg(Date)
   POSIXt <- match.arg(POSIXt)
+  difftime <- match.arg(difftime)
   factor <- match.arg(factor)
   complex <- match.arg(complex)
   raw <- match.arg(raw)
@@ -28,7 +29,7 @@ toJSON <- function(x, dataframe = c("rows", "columns", "values"), matrix = c("ro
   indent <- if (isTRUE(pretty)) 0L else NA_integer_
 
   # dispatch
-  ans <- asJSON(x, dataframe = dataframe, Date = Date, POSIXt = POSIXt, factor = factor,
+  ans <- asJSON(x, dataframe = dataframe, Date = Date, POSIXt = POSIXt, difftime = difftime, factor = factor,
     complex = complex, raw = raw, matrix = matrix, auto_unbox = auto_unbox, digits = digits,
     na = na, null = null, force = force, indent = indent, ...)
 

--- a/man/fromJSON.Rd
+++ b/man/fromJSON.Rd
@@ -5,18 +5,12 @@
 \alias{fromJSON}
 \alias{toJSON}
 \alias{jsonlite}
-\alias{toJSON}
 \title{Convert \R{} objects to/from JSON}
 \usage{
 fromJSON(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVector,
   simplifyMatrix = simplifyVector, flatten = FALSE, ...)
 
-toJSON(x, dataframe = c("rows", "columns", "values"), matrix = c("rowmajor",
-  "columnmajor"), Date = c("ISO8601", "epoch"), POSIXt = c("string",
-  "ISO8601", "epoch", "mongo"), factor = c("string", "integer"),
-  complex = c("string", "list"), raw = c("base64", "hex", "mongo"),
-  null = c("list", "null"), na = c("null", "string"), auto_unbox = FALSE,
-  digits = 4, pretty = FALSE, force = FALSE, ...)
+toJSON(...)
 }
 \arguments{
 \item{txt}{a JSON string, URL or file}
@@ -41,6 +35,8 @@ toJSON(x, dataframe = c("rows", "columns", "values"), matrix = c("rowmajor",
 
 \item{POSIXt}{how to encode POSIXt (datetime) objects: must be one of 'string', 'ISO8601', 'epoch' or 'mongo'}
 
+\item{difftime}{how to encode difftime objects: must be either 'string' or 'epoch'}
+
 \item{factor}{how to encode factor objects: must be one of 'string' or 'integer'}
 
 \item{complex}{how to encode complex numbers: must be one of 'string' or 'list'}
@@ -56,9 +52,9 @@ An exception is that objects of class \code{AsIs} (i.e. wrapped in \code{I()}) a
 
 \item{digits}{max number of decimal digits to print for numeric values. Use \code{I()} to specify significant digits. Use \code{NA} for max precision.}
 
-\item{pretty}{adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}}
-
 \item{force}{unclass/skip objects of classes with no defined JSON mapping}
+
+\item{pretty}{adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}}
 }
 \description{
 These functions are used to convert between JSON data and \R{} objects. The \code{\link{toJSON}} and \code{\link{fromJSON}}
@@ -93,7 +89,8 @@ fromJSON('{"city" : "Z\\\\u00FCrich"}')
 toJSON(pi, digits=3)
 toJSON(pi, digits=I(3))
 
-\dontrun{retrieve data frame
+\dontrun{
+#retrieve data frame
 data1 <- fromJSON("https://api.github.com/users/hadley/orgs")
 names(data1)
 data1$login

--- a/tests/testthat/test-toJSON-difftime.R
+++ b/tests/testthat/test-toJSON-difftime.R
@@ -1,0 +1,39 @@
+context("toJSON difftime")
+objectSecs <- as.POSIXct("1985-06-18 14:23:00") - (as.POSIXct("1985-06-18 14:23:00") - 2);
+objectMins <- as.POSIXct("1985-06-18 14:23:00") - (as.POSIXct("1985-06-18 14:23:00") - 120);
+objectHours <- as.POSIXct("1985-06-18 14:23:00") - (as.POSIXct("1985-06-18 14:23:00") - 7200);
+objectDays <- as.POSIXct("1985-06-18 14:23:00")- (as.POSIXct("1985-06-18 14:23:00") - 172800);
+
+test_that("Encoding difftime Objects", {
+  expect_that(toJSON(objectSecs), equals("[\"2 secs\"]"));
+  expect_that(toJSON(objectMins), equals("[\"2 mins\"]"));
+  expect_that(toJSON(objectHours), equals("[\"2 hours\"]"));
+  expect_that(toJSON(objectDays), equals("[\"2 days\"]"));
+
+  expect_that(toJSON(objectSecs, difftime = "string"), equals("[\"2 secs\"]"));
+  expect_that(toJSON(objectMins, difftime = "string"), equals("[\"2 mins\"]"));
+  expect_that(toJSON(objectHours, difftime = "string"), equals("[\"2 hours\"]"));
+  expect_that(toJSON(objectDays, difftime = "string"), equals("[\"2 days\"]"));
+
+  expect_that(toJSON(objectSecs, difftime = "epoch"), equals("[2]"));
+  expect_that(toJSON(objectMins, difftime = "epoch"), equals("[120]"));
+  expect_that(toJSON(objectHours, difftime = "epoch"), equals("[7200]"));
+  expect_that(toJSON(objectDays, difftime = "epoch"), equals("[172800]"));
+
+  expect_that(toJSON(objectSecs, difftime="adsfdsfds"), throws_error("should be one of"));
+
+});
+
+test_that("Encoding difftime Objects in a list", {
+  expect_that(toJSON(list(foo=objectSecs)), equals("{\"foo\":[\"2 secs\"]}"));
+  expect_that(toJSON(list(foo=objectSecs), difftime="string"), equals("{\"foo\":[\"2 secs\"]}"));
+  expect_that(toJSON(list(foo=objectSecs), difftime="epoch"), equals("{\"foo\":[2]}"));
+  expect_that(toJSON(list(foo=objectSecs), difftime="adsfdsfds"), throws_error("should be one of"));
+});
+
+test_that("Encoding Date Objects in a Data frame", {
+  expect_that(toJSON(data.frame(foo=objectSecs)), equals("[{\"foo\":\"2 secs\"}]"));
+  expect_that(toJSON(data.frame(foo=objectSecs), difftime="string"), equals("[{\"foo\":\"2 secs\"}]"));
+  expect_that(toJSON(data.frame(foo=objectSecs), difftime="epoch"), equals("[{\"foo\":2}]"));
+  expect_that(toJSON(data.frame(foo=objectSecs), difftime="adsfdsfds"), throws_error("should be one of"));
+});


### PR DESCRIPTION
asJSON difftime has two options:
`string` : that will return the difference of time as a sentence, e.g: `2 secs`, `2 mins`, etc
`epoch`: that will return the plain number of seconds difference as a integer