### PR TITLE
Add extra 0 to loosen line length

### DIFF
--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -83,7 +83,7 @@ fromJSON <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVec
   }
 
   # overload for URL or path
-  if (is.character(txt) && length(txt) == 1 && nchar(txt, type="bytes") < 1000 && !validate(txt)) {
+  if (is.character(txt) && length(txt) == 1 && nchar(txt, type="bytes") < 10000 && !validate(txt)) {
     if (grepl("^https?://", txt, useBytes=TRUE)) {
       loadpkg("curl")
       h <- curl::new_handle(useragent = paste("jsonlite /", R.version.string))


### PR DESCRIPTION
In line 86, there is a limit on the number of characters that can be on a line.  Change this limit from 1000 (one thousand) to 10000 (ten thousand).

Consider changing 1000 character limit back to 10000 because 1000 is too limited for long URLs.