### PR TITLE
Allow non-recursion of simplify

### DIFF
--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -23,6 +23,7 @@
 #' @param simplifyVector coerce JSON arrays containing only primitives into an atomic vector
 #' @param simplifyDataFrame coerce JSON arrays containing only records (JSON objects) into a data frame
 #' @param simplifyMatrix coerce JSON arrays containing vectors of equal mode and dimension into matrix or array
+#' @param recursive simplify recursively
 #' @param flatten automatically \code{\link{flatten}} nested data frames into a single non-nested data frame
 #' @param x the object to be encoded
 #' @param dataframe how to encode data.frame objects: must be one of 'rows', 'columns' or 'values'
@@ -75,7 +76,7 @@
 #' identical(data3, flatten(data2))
 #' }
 fromJSON <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVector,
-  simplifyMatrix = simplifyVector, flatten = FALSE, ...) {
+  simplifyMatrix = simplifyVector, recursive = TRUE, flatten = FALSE, ...) {
 
   # check type
   if (!is.character(txt) && !inherits(txt, "connection")) {
@@ -98,11 +99,11 @@ fromJSON <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVec
 
   # call the actual function (with deprecated arguments)
   fromJSON_string(txt = txt, simplifyVector = simplifyVector, simplifyDataFrame = simplifyDataFrame,
-    simplifyMatrix = simplifyMatrix, flatten = flatten, ...)
+    simplifyMatrix = simplifyMatrix, recursive = TRUE, flatten = flatten, ...)
 }
 
 fromJSON_string <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVector,
-  simplifyMatrix = simplifyVector, flatten = FALSE, unicode = TRUE, validate = TRUE, bigint_as_char = FALSE, ...){
+  simplifyMatrix = simplifyVector, recursive = TRUE, flatten = FALSE, unicode = TRUE, validate = TRUE, bigint_as_char = FALSE, ...){
 
   if(!missing(unicode)){
     message("Argument unicode has been deprecated. YAJL always parses unicode.")
@@ -118,7 +119,7 @@ fromJSON_string <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simp
   # post processing
   if (any(isTRUE(simplifyVector), isTRUE(simplifyDataFrame), isTRUE(simplifyMatrix))) {
     return(simplify(obj, simplifyVector = simplifyVector, simplifyDataFrame = simplifyDataFrame,
-      simplifyMatrix = simplifyMatrix, flatten = flatten, ...))
+      simplifyMatrix = simplifyMatrix, recursive = recursive, flatten = flatten, ...))
   } else {
     return(obj)
   }

--- a/R/simplify.R
+++ b/R/simplify.R
@@ -1,6 +1,6 @@
 simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplifyMatrix = TRUE,
   simplifyDate = simplifyVector, homoList = TRUE, flatten = FALSE, columnmajor = FALSE,
-  simplifySubMatrix = simplifyMatrix) {
+  simplifySubMatrix = simplifyMatrix, recursive = TRUE) {
 
   #This includes '[]' and '{}')
   if (!is.list(x) || !length(x)) {
@@ -9,7 +9,7 @@ simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplif
 
   # list can be a dataframe recordlist
   if (isTRUE(simplifyDataFrame) && is.recordlist(x)) {
-    mydf <- simplifyDataFrame(x, flatten = flatten, simplifyMatrix = simplifySubMatrix)
+    mydf <- simplifyDataFrame(x, flatten = flatten, simplifyMatrix = simplifySubMatrix, recursive = recursive)
     if(isTRUE(simplifyDate) && is.data.frame(mydf) && is.datelist(mydf)){
       return(parse_date(mydf[["$date"]]))
     }
@@ -21,9 +21,13 @@ simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplif
     return(list_to_vec(x))
   }
 
+  out <- x
+
   # apply recursively
-  out <- lapply(x, simplify, simplifyVector = simplifyVector, simplifyDataFrame = simplifyDataFrame,
-    simplifyMatrix = simplifySubMatrix, columnmajor = columnmajor, flatten = flatten)
+  if (isTRUE(recursive)) {
+    out <- lapply(x, simplify, simplifyVector = simplifyVector, simplifyDataFrame = simplifyDataFrame,
+      simplifyMatrix = simplifySubMatrix, columnmajor = columnmajor, flatten = flatten)
+  }
 
   # fix for mongo style dates turning into scalars *after* simplifying
   # only happens when simplifyDataframe=FALSE

--- a/R/simplifyDataFrame.R
+++ b/R/simplifyDataFrame.R
@@ -1,4 +1,4 @@
-simplifyDataFrame <- function(recordlist, columns, flatten, simplifyMatrix) {
+simplifyDataFrame <- function(recordlist, columns, flatten, simplifyMatrix, recursive = TRUE) {
 
   # no records at all
   if (!length(recordlist)) {
@@ -26,8 +26,8 @@ simplifyDataFrame <- function(recordlist, columns, flatten, simplifyMatrix) {
   columnlist <- transpose_list(recordlist, columns)
 
   # simplify vectors and nested data frames
-  columnlist <- lapply(columnlist, simplify, simplifyVector = TRUE, simplifyDataFrame = TRUE,
-    simplifyMatrix = FALSE, simplifySubMatrix = simplifyMatrix, flatten = flatten)
+  columnlist <- lapply(columnlist, simplify, simplifyVector = recursive, simplifyDataFrame = recursive,
+    simplifyMatrix = FALSE, simplifySubMatrix = simplifyMatrix, flatten = flatten, recursive = recursive)
 
   # check that all elements have equal length
   columnlengths <- unlist(vapply(columnlist, function(z) {

--- a/man/fromJSON.Rd
+++ b/man/fromJSON.Rd
@@ -9,7 +9,7 @@
 \title{Convert \R{} objects to/from JSON}
 \usage{
 fromJSON(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVector,
-  simplifyMatrix = simplifyVector, flatten = FALSE, ...)
+  simplifyMatrix = simplifyVector, recursive = TRUE, flatten = FALSE, ...)
 
 toJSON(x, dataframe = c("rows", "columns", "values"), matrix = c("rowmajor",
   "columnmajor"), Date = c("ISO8601", "epoch"), POSIXt = c("string",
@@ -26,6 +26,8 @@ toJSON(x, dataframe = c("rows", "columns", "values"), matrix = c("rowmajor",
 \item{simplifyDataFrame}{coerce JSON arrays containing only records (JSON objects) into a data frame}
 
 \item{simplifyMatrix}{coerce JSON arrays containing vectors of equal mode and dimension into matrix or array}
+
+\item{recursive}{simplify recursively}
 
 \item{flatten}{automatically \code{\link{flatten}} nested data frames into a single non-nested data frame}
 
@@ -93,7 +95,8 @@ fromJSON('{"city" : "Z\\\\u00FCrich"}')
 toJSON(pi, digits=3)
 toJSON(pi, digits=I(3))
 
-\dontrun{retrieve data frame
+\dontrun{
+#retrieve data frame
 data1 <- fromJSON("https://api.github.com/users/hadley/orgs")
 names(data1)
 data1$login


### PR DESCRIPTION
Thanks for the wonderful package.

This PR is to allow the various `simplify*` arguments to be applied non-recursively.  In particular it can be easier to handle nested data if it isn't converted to a dataframe column.

If it's reasonable new feature, then I'll add tests.