### PR TITLE
Updates the mongo-style raw encoding to match v2 of the Extended JSON spec

### DIFF
--- a/R/asJSON.raw.R
+++ b/R/asJSON.raw.R
@@ -6,7 +6,7 @@ setMethod("asJSON", "raw", function(x, raw = c("base64", "hex", "mongo"), ...) {
   # encode based on schema
   if (raw == "mongo") {
     type <- ifelse(length(attr(x, "type")), attr(x, "type"), 5)
-    return(asJSON(list(`$binary` = as.scalar(base64_enc(x)), `$type` = as.scalar(as.character(type)))))
+    return(asJSON(list(`$binary` = list(`base64` = as.scalar(base64_enc(x)), `subType` = as.scalar(as.character(type))))))
   } else if (raw == "hex") {
     return(asJSON(as.character.hexmode(x), ...))
   } else {


### PR DESCRIPTION
The `$binary` format has changed as of May 2017 (see [commit](https://github.com/mongodb/specifications/commit/c6d7ac82cc48800171678b9515c92d69d5bebbcd)). Before, we had

`{"x" : {"$binary" : "//8=", "$type" : "00"}}`

and now we have e.g.

`{"x" : { "$binary" : {"base64" : "//8=", "subType" : "00"}}}`

This commit should implement the new format. I believe this may be a breaking change for some users, but since they are likely interacting with MongoDB is some way they'll have to change at some point anyway.