### PR TITLE
allow handling of `auto_unbox` and `digits` parameters in `toJSON` 

### DIFF
--- a/R/toJSON.R
+++ b/R/toJSON.R
@@ -2,8 +2,8 @@
 toJSON <- function(x, dataframe = c("rows", "columns", "values"), matrix = c("rowmajor", "columnmajor"),
   Date = c("ISO8601", "epoch"), POSIXt = c("string", "ISO8601", "epoch", "mongo"),
   factor = c("string", "integer"), complex = c("string", "list"), raw = c("base64", "hex", "mongo"),
-  null = c("list", "null"), na = c("null", "string"), auto_unbox = FALSE, digits = 4,
-  pretty = FALSE, force = FALSE, ...) {
+  null = c("list", "null"), na = c("null", "string"), auto_unbox = getOption("jsonlite.auto_unbox", FALSE),
+  digits = getOption("jsonlite.digits", 4), pretty = FALSE, force = FALSE, ...) {
 
   # validate args
   dataframe <- match.arg(dataframe)

--- a/man/fromJSON.Rd
+++ b/man/fromJSON.Rd
@@ -15,8 +15,10 @@ toJSON(x, dataframe = c("rows", "columns", "values"), matrix = c("rowmajor",
   "columnmajor"), Date = c("ISO8601", "epoch"), POSIXt = c("string",
   "ISO8601", "epoch", "mongo"), factor = c("string", "integer"),
   complex = c("string", "list"), raw = c("base64", "hex", "mongo"),
-  null = c("list", "null"), na = c("null", "string"), auto_unbox = FALSE,
-  digits = 4, pretty = FALSE, force = FALSE, ...)
+  null = c("list", "null"), na = c("null", "string"),
+  auto_unbox = getOption("jsonlite.auto_unbox", FALSE),
+  digits = getOption("jsonlite.digits", 4), pretty = FALSE, force = FALSE,
+  ...)
 }
 \arguments{
 \item{txt}{a JSON string, URL or file}
@@ -93,7 +95,8 @@ fromJSON('{"city" : "Z\\\\u00FCrich"}')
 toJSON(pi, digits=3)
 toJSON(pi, digits=I(3))
 
-\dontrun{retrieve data frame
+\dontrun{
+#retrieve data frame
 data1 <- fromJSON("https://api.github.com/users/hadley/orgs")
 names(data1)
 data1$login


### PR DESCRIPTION
I've encountered a use case where I need to be able to set `auto_unbox` and `digits` in calls to `toJSON` that are being made by other R packages I haven't written, and a minimally intrusive way to gain control over these parameters is if the default values use R options. Then, I can set these options in my R session and control the behavior of `toJSON` without editing the calls in code.

I've preserved the original default values as fallback values in case the R options are not set.

Happy to write tests - but in order to test this functionality I'd want to use `withr` to avoid polluting the test environment, and would rather not add a dependency unless the repo admins are okay with this.