### PR TITLE
Allow auto_unbox=TRUE when dataframe="column"

### DIFF
--- a/R/asJSON.data.frame.R
+++ b/R/asJSON.data.frame.R
@@ -1,6 +1,6 @@
 setMethod("asJSON", "data.frame", function(x, na = c("NA", "null", "string"), collapse = TRUE,
   dataframe = c("rows", "columns", "values"), complex = "string", oldna = NULL, rownames = NULL,
-  keep_vec_names = FALSE, indent = NA_integer_, no_dots = FALSE, ...) {
+  keep_vec_names = FALSE, auto_unbox = FALSE, indent = NA_integer_, no_dots = FALSE, ...) {
 
   # Coerse pairlist if needed
   if (is.pairlist(x)) {
@@ -35,7 +35,7 @@ setMethod("asJSON", "data.frame", function(x, na = c("NA", "null", "string"), co
   # Column based is same as list. Do not pass collapse arg because it is a named list.
   if (dataframe == "columns") {
     return(asJSON(as.list(x), is_df = TRUE, na = na, dataframe = dataframe,
-      complex = complex, rownames = rownames, indent = indent, no_dots = no_dots, ...))
+      complex = complex, rownames = rownames, auto_unbox = auto_unbox, indent = indent, no_dots = no_dots, ...))
   }
 
   # Determine "oldna". This is needed when the data frame contains a list column

--- a/R/asJSON.list.R
+++ b/R/asJSON.list.R
@@ -29,7 +29,7 @@ setMethod("asJSON", "list", function(x, collapse = TRUE, na = NULL, oldna = NULL
   # note we are NOT passing on the container argument.
   tmp <- if(is_df && auto_unbox){
     vapply(x, function(y, ...) {
-      asJSON(y, auto_unbox = is.list(y), ...)
+      asJSON(y, auto_unbox = auto_unbox || is.list(y), ...)
     }, character(1), na = na, indent = indent + 2L, no_dots = no_dots, ...)
   } else {
     vapply(x, asJSON, character(1), na = na, auto_unbox = auto_unbox, indent = indent + 2L, no_dots = no_dots, ...)


### PR DESCRIPTION
`auto_unbox=TRUE` in `toJSON()` has been ignored when `dataframe="column"` since 65680f68; therefore it was not possible to unbox single-row data.frames automatically:

```r
iris1 = head(iris, 1L)
cat(toJSON(iris1, dataframe = "column", auto_unbox = TRUE, pretty = TRUE))
#> {
#>   "Sepal.Length": [5.1],
#>   "Sepal.Width": [3.5],
#>   "Petal.Length": [1.4],
#>   "Petal.Width": [0.2],
#>   "Species": ["setosa"]
#> }
```

This PR enables it:
```r
iris1 = head(iris, 1L)
cat(toJSON(iris1, dataframe = "column", auto_unbox = TRUE, pretty = TRUE))
#> {
#>   "Sepal.Length": 5.1,
#>   "Sepal.Width": 3.5,
#>   "Petal.Length": 1.4,
#>   "Petal.Width": 0.2,
#>   "Species": "setosa"
#> }
```

Note that it is slightly different from what we get from `dataframe="row"`:
```r
iris1 = head(iris, 1L)
cat(toJSON(iris1, dataframe = "row", pretty = TRUE))
#> [
#>   {
#>     "Sepal.Length": 5.1,
#>     "Sepal.Width": 3.5,
#>     "Petal.Length": 1.4,
#>     "Petal.Width": 0.2,
#>     "Species": "setosa"
#>   }
#> ]
```