### PR TITLE
Add option to include duplicate names in a list object being written 

### DIFF
--- a/R/asJSON.list.R
+++ b/R/asJSON.list.R
@@ -1,5 +1,5 @@
 setMethod("asJSON", "list", function(x, collapse = TRUE, na = NULL, oldna = NULL,
-  is_df = FALSE, auto_unbox = FALSE, indent = NA_integer_, no_dots = FALSE, ...) {
+  is_df = FALSE, auto_unbox = FALSE, indent = NA_integer_, no_dots = FALSE, dup_names = FALSE, ...) {
 
   # reset na arg when called from data frame
   if(identical(na, "NA")){
@@ -41,7 +41,7 @@ setMethod("asJSON", "list", function(x, collapse = TRUE, na = NULL, oldna = NULL
       warning("collapse=FALSE called for named list.")
     }
     #in case of named list:
-    objnames <- deparse_vector(cleannames(names(x), no_dots = no_dots))
+    objnames <- deparse_vector(cleannames(names(x), no_dots = no_dots, dup_names = dup_names))
     collapse_object(objnames, tmp, indent)
   } else {
     #in case of unnamed list:

--- a/R/cleannames.R
+++ b/R/cleannames.R
@@ -1,8 +1,10 @@
-cleannames <- function(objnames, no_dots = FALSE){
+cleannames <- function(objnames, no_dots = FALSE, dup_names = FALSE){
   objnames[objnames == ""] <- NA_character_
   is_missing <- is.na(objnames)
   objnames[is_missing] <- as.character(seq_len(length(objnames)))[is_missing]
   if(isTRUE(no_dots))
     objnames <- gsub(".", "_", objnames, fixed = TRUE)
-  make.unique(objnames)
+  if(isFALSE(dup_names))
+    objnames <- make.unique(objnames)
+  objnames
 }


### PR DESCRIPTION
Includes new argument `dup_names` which if true allows a list to have multiple list items with the same name