### PR TITLE
Fix spelling in NEWS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@
  - Hide internal libyajl symbols from shlib
  - Remove C calls R connection API which are no longer allowed on CRAN. This may
    lead to about 5% performance decrease for parsing from connections.
- - Remove depreacted rbind.pages function
+ - Remove deprecated rbind.pages function
 
 1.5
  - Workaround for #180. fromJSON() first checks for literal json, then filename


### PR DESCRIPTION
I saw there was a new release of jsonlite, so I went to read what fun new stuff was in the release, and I noticed this little typo. Figured it was easy enough to just fix it. Thanks for all your work on this package!