### PR TITLE
consitently deal with NA's for POSIXt = "mongo"

### DIFF
--- a/R/asJSON.POSIXt.R
+++ b/R/asJSON.POSIXt.R
@@ -1,5 +1,6 @@
 setMethod("asJSON", "POSIXt", function(x, POSIXt = c("string", "ISO8601", "epoch",
-  "mongo"), UTC = FALSE, digits, time_format = NULL, always_decimal = FALSE, ...) {
+  "mongo"), UTC = FALSE, digits, time_format = NULL, always_decimal = FALSE,
+  na = c("null", "string", "NA"), ...) {
   # note: UTC argument doesn't seem to be working consistently maybe use ?format
   # instead of ?as.character
 
@@ -14,7 +15,18 @@ setMethod("asJSON", "POSIXt", function(x, POSIXt = c("string", "ISO8601", "epoch
     df <- data.frame("$date" = floor(unclass(x) * 1000), check.names = FALSE)
     if(inherits(x, "scalar"))
       class(df) <- c("scalar", class(df))
-    return(asJSON(df, digits = NA, always_decimal = FALSE, ...))
+    tmp <- asJSON(df, digits = NA, always_decimal = FALSE, ...)
+    if (any(missings <- which(is.na(x)))) {
+      na <- match.arg(na)
+      if (na %in% c("null")) {
+        tmp[missings] <- "null"
+      } else if(na %in% "string") {
+        tmp[missings] <- "\"NA\""
+      } else {
+        tmp[missings] <- NA_character_
+      }
+    }
+    return(tmp)
   }
 
   # Epoch millis

--- a/R/asJSON.POSIXt.R
+++ b/R/asJSON.POSIXt.R
@@ -19,9 +19,9 @@ setMethod("asJSON", "POSIXt", function(x, POSIXt = c("string", "ISO8601", "epoch
     if (any(missings <- which(is.na(x)))) {
       na <- match.arg(na)
       if (na %in% c("null")) {
-        tmp[missings] <- "null"
+        tmp <- gsub("{}","null", tmp, fixed = TRUE)
       } else if(na %in% "string") {
-        tmp[missings] <- "\"NA\""
+        tmp <- gsub("{}","\"NA\"", tmp, fixed = TRUE)
       } else {
         tmp[missings] <- NA_character_
       }

--- a/R/asJSON.POSIXt.R
+++ b/R/asJSON.POSIXt.R
@@ -31,7 +31,7 @@ setMethod("asJSON", "POSIXt", function(x, POSIXt = c("string", "ISO8601", "epoch
 
   # Epoch millis
   if (POSIXt == "epoch") {
-    return(asJSON(floor(unclass(as.POSIXct(x)) * 1000), digits = digits, always_decimal = FALSE, ...))
+    return(asJSON(floor(unclass(as.POSIXct(x)) * 1000), digits = digits, always_decimal = FALSE, na = na, ...))
   }
 
   # Strings
@@ -46,8 +46,8 @@ setMethod("asJSON", "POSIXt", function(x, POSIXt = c("string", "ISO8601", "epoch
   }
 
   if (isTRUE(UTC)) {
-    asJSON(as.character(x, format = time_format, tz = "UTC"), ...)
+    asJSON(as.character(x, format = time_format, tz = "UTC"), na = na, ...)
   } else {
-    asJSON(as.character(x, format = time_format), ...)
+    asJSON(as.character(x, format = time_format), na = na, ...)
   }
 })

--- a/R/is.recordlist.R
+++ b/R/is.recordlist.R
@@ -24,3 +24,10 @@ is.namedlist <- function(x) {
 is.unnamedlist <- function(x) {
   isTRUE(is.list(x) && is.null(names(x)))
 }
+
+is.mongoposixtlist <- function(x) {
+  isTRUE(is.list(x)) &&
+    unique(unlist(lapply(x,names))) == "$date" &&
+    all(sapply(x, length) == 1) &&
+    is.recordlist(x[sapply(lapply(x,names),length)])
+}

--- a/R/simplify.R
+++ b/R/simplify.R
@@ -6,9 +6,8 @@ simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplif
   if (!is.list(x) || !length(x)) {
     return(x)
   }
-
-  # list can be a dataframe recordlist
-  if (isTRUE(simplifyDataFrame) && is.recordlist(x)) {
+  # list can be a dataframe recordlist or a mongo posixt recordlist
+  if (isTRUE(simplifyDataFrame) && (is.recordlist(x) || is.mongoposixtlist(x))) {
     mydf <- simplifyDataFrame(x, flatten = flatten, simplifyMatrix = simplifySubMatrix)
     if(isTRUE(simplifyDate) && is.data.frame(mydf) && is.datelist(mydf)){
       return(parse_date(mydf[["$date"]]))

--- a/tests/testthat/test-toJSON-POSIXt.R
+++ b/tests/testthat/test-toJSON-POSIXt.R
@@ -68,10 +68,20 @@ test_that("POSIXt NA values", {
     expect_that(toJSON(data.frame(foo=object)), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{}]"));
     expect_that(toJSON(data.frame(foo=object), na="null"), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":null}]"));
     expect_that(toJSON(data.frame(foo=object), na="string"), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":\"NA\"}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo"), equals("[{\"foo\":{\"$date\":1371508424000}},{}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="null"), equals("[{\"foo\":{\"$date\":1371508424000}},{\"foo\":null}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="string"), equals("[{\"foo\":{\"$date\":1371508424000}},{\"foo\":\"NA\"}]"));
   });
+
+  tzobject <- list(
+    c(objects[[3]], NA),
+    c(objects[[4]], NA)
+  )
+
+  lapply(tzobj, function(object) {
+    expect_that(toJSON(object, POSIXt = "mongo"), equals("[{\"$date\":1371474224000},null]"));
+    expect_that(toJSON(object, POSIXt = "mongo", na="string"), equals("[{\"$date\":1371474224000},\"NA\"]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo"), equals("[{\"foo\":{\"$date\":1371474224000}},{}]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="null"), equals("[{\"foo\":{\"$date\":1371474224000}},{\"foo\":null}]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="string"), equals("[{\"foo\":{\"$date\":1371474224000}},{\"foo\":\"NA\"}]"));
+  })
 });
 
 test_that("Negative dates", {

--- a/tests/testthat/test-toJSON-POSIXt.R
+++ b/tests/testthat/test-toJSON-POSIXt.R
@@ -70,11 +70,10 @@ test_that("POSIXt NA values", {
     expect_that(toJSON(data.frame(foo=object), na="string"), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":\"NA\"}]"));
   });
 
-  tzobject <- list(
+  tzobj <- list(
     c(objects[[3]], NA),
     c(objects[[4]], NA)
-  )
-
+  );
   lapply(tzobj, function(object) {
     expect_that(toJSON(object, POSIXt = "mongo"), equals("[{\"$date\":1371474224000},null]"));
     expect_that(toJSON(object, POSIXt = "mongo", na="string"), equals("[{\"$date\":1371474224000},\"NA\"]"));

--- a/tests/testthat/test-toJSON-POSIXt.R
+++ b/tests/testthat/test-toJSON-POSIXt.R
@@ -68,6 +68,9 @@ test_that("POSIXt NA values", {
     expect_that(toJSON(data.frame(foo=object)), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{}]"));
     expect_that(toJSON(data.frame(foo=object), na="null"), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":null}]"));
     expect_that(toJSON(data.frame(foo=object), na="string"), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":\"NA\"}]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo"), equals("[{\"foo\":{\"$date\":1371501224000}},{}]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="null"), equals("[{\"foo\":{\"$date\":1371501224000}},{\"foo\":null}]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="string"), equals("[{\"foo\":{\"$date\":1371501224000}},{\"foo\":\"NA\"}]"));
   });
 });
 

--- a/tests/testthat/test-toJSON-POSIXt.R
+++ b/tests/testthat/test-toJSON-POSIXt.R
@@ -68,9 +68,9 @@ test_that("POSIXt NA values", {
     expect_that(toJSON(data.frame(foo=object)), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{}]"));
     expect_that(toJSON(data.frame(foo=object), na="null"), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":null}]"));
     expect_that(toJSON(data.frame(foo=object), na="string"), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":\"NA\"}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo"), equals("[{\"foo\":{\"$date\":1371501224000}},{}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="null"), equals("[{\"foo\":{\"$date\":1371501224000}},{\"foo\":null}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="string"), equals("[{\"foo\":{\"$date\":1371501224000}},{\"foo\":\"NA\"}]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo"), equals("[{\"foo\":{\"$date\":1371508424000}},{}]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="null"), equals("[{\"foo\":{\"$date\":1371508424000}},{\"foo\":null}]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="string"), equals("[{\"foo\":{\"$date\":1371508424000}},{\"foo\":\"NA\"}]"));
   });
 });
 


### PR DESCRIPTION
Fixing https://github.com/jeroen/jsonlite/issues/277

I re-used the encode logic in asJSON.character to validate `NA`s to make sure they are dealt with consistently compared to other types.

After rendering the original json for `POSIXt` vectors, I replace `{}`, `{"$date":null}` or `{"$date":"NA"}` with `NA_character_`, `"null"` or `"\"NA\""` respectively