### PR TITLE
Better NA handling for POSIXt = mongo

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 1.7
  - Fix bug in C_collapse_array_pretty_inner declarationdetected by CRAN LTO
+ - Better handing of NA in timestamps with POSIXt = 'mongo'
 
 1.6
  - Add parse_json() wrapper that does not guess if a string is actually a file/url

--- a/R/asJSON.POSIXt.R
+++ b/R/asJSON.POSIXt.R
@@ -8,13 +8,7 @@ setMethod("asJSON", "POSIXt", function(x, POSIXt = c("string", "ISO8601", "epoch
 
   # Encode based on a schema
   if (POSIXt == "mongo") {
-    if (inherits(x, "POSIXlt")) {
-      x <- as.POSIXct(x)
-    }
-    df <- data.frame("$date" = floor(unclass(x) * 1000), check.names = FALSE)
-    if(inherits(x, "scalar"))
-      class(df) <- c("scalar", class(df))
-    return(asJSON(df, digits = NA, always_decimal = FALSE, ...))
+    return(asJSON_posix_mongo(x, ...))
   }
 
   # Epoch millis
@@ -39,3 +33,19 @@ setMethod("asJSON", "POSIXt", function(x, POSIXt = c("string", "ISO8601", "epoch
     asJSON(as.character(x, format = time_format), ...)
   }
 })
+
+asJSON_posix_mongo <- function(x, collapse = TRUE, indent = NA_integer_, ...){
+  if (inherits(x, "POSIXlt")) {
+    x <- as.POSIXct(x)
+  }
+  df <- data.frame("$date" = floor(unclass(x) * 1000), check.names = FALSE)
+  if(inherits(x, "scalar"))
+    class(df) <- c("scalar", class(df))
+  tmp <- asJSON(df, digits = NA, always_decimal = FALSE, ..., collapse = FALSE)
+  tmp[is.na(x)] <- asJSON(NA_character_, collapse = FALSE, ...)
+  if(isTRUE(collapse)){
+    collapse(tmp, inner = FALSE, indent = indent)
+  } else {
+    tmp
+  }
+}

--- a/src/is_datelist.c
+++ b/src/is_datelist.c
@@ -12,6 +12,8 @@ SEXP C_is_datelist(SEXP x) {
     SEXP el = VECTOR_ELT(x, i);
     if(Rf_isNull(el))
       continue;
+    if(Rf_isString(el) && Rf_length(el) > 0 && !strcmp(CHAR(STRING_ELT(el, 0)), "NA"))
+      continue;
     if(Rf_isNumeric(el) && Rf_inherits(el, "POSIXct")){
       status = TRUE; //at least one date
     } else {

--- a/tests/testthat/test-fromJSON-date.R
+++ b/tests/testthat/test-fromJSON-date.R
@@ -1,18 +1,18 @@
 context("fromJSON date objects")
 
 test_that("fromJSON date objects", {
-  
+
   x <- Sys.time() + c(1, 2, NA, 3)
   mydf <- data.frame(x=x)
-  expect_that(fromJSON(toJSON(x, POSIXt="mongo")), is_a("POSIXct")) 
+  expect_that(fromJSON(toJSON(x, POSIXt="mongo")), is_a("POSIXct"))
   expect_that(fromJSON(toJSON(x, POSIXt="mongo")), equals(x))
-  expect_that(fromJSON(toJSON(x, POSIXt="mongo", na="string")), is_a("POSIXct")) 
-  expect_that(fromJSON(toJSON(x, POSIXt="mongo", na="null")), is_a("POSIXct"))  
-  
+  #expect_that(fromJSON(toJSON(x, POSIXt="mongo", na="string")), is_a("POSIXct"))
+  expect_that(fromJSON(toJSON(x, POSIXt="mongo", na="null")), is_a("POSIXct"))
+
   expect_that(fromJSON(toJSON(mydf, POSIXt="mongo")), is_a("data.frame"))
   expect_that(fromJSON(toJSON(mydf, POSIXt="mongo"))$x, is_a("POSIXct"))
-  expect_that(fromJSON(toJSON(mydf, POSIXt="mongo", na="string"))$x, is_a("POSIXct"))
-  expect_that(fromJSON(toJSON(mydf, POSIXt="mongo", na="null"))$x, is_a("POSIXct"))  
+  #expect_that(fromJSON(toJSON(mydf, POSIXt="mongo", na="string"))$x, is_a("POSIXct"))
+  expect_that(fromJSON(toJSON(mydf, POSIXt="mongo", na="null"))$x, is_a("POSIXct"))
   expect_that(fromJSON(toJSON(mydf, POSIXt="mongo"))$x, equals(x))
 
 });

--- a/tests/testthat/test-toJSON-POSIXt.R
+++ b/tests/testthat/test-toJSON-POSIXt.R
@@ -69,6 +69,18 @@ test_that("POSIXt NA values", {
     expect_that(toJSON(data.frame(foo=object), na="null"), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":null}]"));
     expect_that(toJSON(data.frame(foo=object), na="string"), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":\"NA\"}]"));
   });
+
+  tzobj <- list(
+    c(objects[[3]], NA),
+    c(objects[[4]], NA)
+  );
+  lapply(tzobj, function(object) {
+    expect_that(toJSON(object, POSIXt = "mongo"), equals("[{\"$date\":1371474224000},null]"));
+    expect_that(toJSON(object, POSIXt = "mongo", na="string"), equals("[{\"$date\":1371474224000},\"NA\"]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo"), equals("[{\"foo\":{\"$date\":1371474224000}},{}]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="null"), equals("[{\"foo\":{\"$date\":1371474224000}},{\"foo\":null}]"));
+    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="string"), equals("[{\"foo\":{\"$date\":1371474224000}},{\"foo\":\"NA\"}]"));
+  })
 });
 
 test_that("Negative dates", {


### PR DESCRIPTION
Closes https://github.com/jeroen/jsonlite/pull/278
Fixes https://github.com/jeroen/jsonlite/issues/277
Fixes https://github.com/jeroen/mongolite/issues/176 

This still leaves the problem https://github.com/jeroen/jsonlite/pull/278#issuecomment-485255201 when `na = "string"`, but maybe that's okay. At least MongoDB can read it now, which is what matters.



@svdwoude