### PR TITLE
Document parameters bigint_as_char and json_verbatim

### DIFF
--- a/R/apply_by_pages.R
+++ b/R/apply_by_pages.R
@@ -4,6 +4,10 @@ apply_by_pages <- function(x, FUN, pagesize, verbose, ...){
   npages <- nr %/% pagesize;
   lastpage <- nr %% pagesize;
 
+  `[.json` <- function(x, i) {
+    structure(NextMethod("["), class = c("json", "character"))
+  }
+
   out <- as.list(rep(NA, npages + as.logical(lastpage)))
   for(i in seq_len(npages)){
     from <- pagesize * (i-1) + 1;

--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -39,6 +39,7 @@
 #' @param digits max number of decimal digits to print for numeric values. Use \code{I()} to specify significant digits. Use \code{NA} for max precision.
 #' @param force unclass/skip objects of classes with no defined JSON mapping
 #' @param pretty adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}
+#' @param json_verbatim do not JSON encode a json character (i.e. a character coming from `toJSON()`) again but leave it as it is
 #' @param ... arguments passed on to class specific \code{print} methods
 #' @references Jeroen Ooms (2014). The \code{jsonlite} Package: A Practical and Consistent Mapping Between JSON Data and \R{} Objects. \emph{arXiv:1403.2805}. \url{https://arxiv.org/abs/1403.2805}
 #' @examples # Stringify some data

--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -40,6 +40,7 @@
 #' @param force unclass/skip objects of classes with no defined JSON mapping
 #' @param pretty adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}
 #' @param json_verbatim do not JSON encode a json character (i.e. a character coming from `toJSON()`) again but leave it as it is
+#' @param bigint_as_char read big integers as character
 #' @param ... arguments passed on to class specific \code{print} methods
 #' @references Jeroen Ooms (2014). The \code{jsonlite} Package: A Practical and Consistent Mapping Between JSON Data and \R{} Objects. \emph{arXiv:1403.2805}. \url{https://arxiv.org/abs/1403.2805}
 #' @examples # Stringify some data
@@ -76,7 +77,7 @@
 #' identical(data3, flatten(data2))
 #' }
 fromJSON <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVector,
-  simplifyMatrix = simplifyVector, flatten = FALSE, ...) {
+  simplifyMatrix = simplifyVector, flatten = FALSE, bigint_as_char = FALSE, ...) {
 
   # check type
   if (!is.character(txt) && !inherits(txt, "connection")) {

--- a/R/toJSON.R
+++ b/R/toJSON.R
@@ -3,7 +3,7 @@ toJSON <- function(x, dataframe = c("rows", "columns", "values"), matrix = c("ro
   Date = c("ISO8601", "epoch"), POSIXt = c("string", "ISO8601", "epoch", "mongo"),
   factor = c("string", "integer"), complex = c("string", "list"), raw = c("base64", "hex", "mongo"),
   null = c("list", "null"), na = c("null", "string"), auto_unbox = FALSE, digits = 4,
-  pretty = FALSE, force = FALSE, ...) {
+  pretty = FALSE, force = FALSE, json_verbatim = FALSE, ...) {
 
   # validate args
   dataframe <- match.arg(dataframe)

--- a/man/fromJSON.Rd
+++ b/man/fromJSON.Rd
@@ -7,17 +7,33 @@
 \alias{jsonlite}
 \title{Convert \R{} objects to/from JSON}
 \usage{
-fromJSON(txt, simplifyVector = TRUE,
-  simplifyDataFrame = simplifyVector, simplifyMatrix = simplifyVector,
-  flatten = FALSE, ...)
+fromJSON(
+  txt,
+  simplifyVector = TRUE,
+  simplifyDataFrame = simplifyVector,
+  simplifyMatrix = simplifyVector,
+  flatten = FALSE,
+  ...
+)
 
-toJSON(x, dataframe = c("rows", "columns", "values"),
-  matrix = c("rowmajor", "columnmajor"), Date = c("ISO8601", "epoch"),
+toJSON(
+  x,
+  dataframe = c("rows", "columns", "values"),
+  matrix = c("rowmajor", "columnmajor"),
+  Date = c("ISO8601", "epoch"),
   POSIXt = c("string", "ISO8601", "epoch", "mongo"),
-  factor = c("string", "integer"), complex = c("string", "list"),
-  raw = c("base64", "hex", "mongo"), null = c("list", "null"),
-  na = c("null", "string"), auto_unbox = FALSE, digits = 4,
-  pretty = FALSE, force = FALSE, ...)
+  factor = c("string", "integer"),
+  complex = c("string", "list"),
+  raw = c("base64", "hex", "mongo"),
+  null = c("list", "null"),
+  na = c("null", "string"),
+  auto_unbox = FALSE,
+  digits = 4,
+  pretty = FALSE,
+  force = FALSE,
+  json_verbatim = FALSE,
+  ...
+)
 }
 \arguments{
 \item{txt}{a JSON string, URL or file}
@@ -60,6 +76,8 @@ An exception is that objects of class \code{AsIs} (i.e. wrapped in \code{I()}) a
 \item{pretty}{adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}}
 
 \item{force}{unclass/skip objects of classes with no defined JSON mapping}
+
+\item{json_verbatim}{do not JSON encode a json character (i.e. a character coming from `toJSON()`) again but leave it as it is}
 }
 \description{
 These functions are used to convert between JSON data and \R{} objects. The \code{\link{toJSON}} and \code{\link{fromJSON}}

--- a/man/fromJSON.Rd
+++ b/man/fromJSON.Rd
@@ -13,6 +13,7 @@ fromJSON(
   simplifyDataFrame = simplifyVector,
   simplifyMatrix = simplifyVector,
   flatten = FALSE,
+  bigint_as_char = FALSE,
   ...
 )
 
@@ -45,6 +46,8 @@ toJSON(
 \item{simplifyMatrix}{coerce JSON arrays containing vectors of equal mode and dimension into matrix or array}
 
 \item{flatten}{automatically \code{\link{flatten}} nested data frames into a single non-nested data frame}
+
+\item{bigint_as_char}{read big integers as character}
 
 \item{...}{arguments passed on to class specific \code{print} methods}
 

--- a/man/stream_in.Rd
+++ b/man/stream_in.Rd
@@ -8,8 +8,7 @@
 \usage{
 stream_in(con, handler = NULL, pagesize = 500, verbose = TRUE, ...)
 
-stream_out(x, con = stdout(), pagesize = 500, verbose = TRUE,
-  prefix = "", ...)
+stream_out(x, con = stdout(), pagesize = 500, verbose = TRUE, prefix = "", ...)
 }
 \arguments{
 \item{con}{a \code{\link{connection}} object. If the connection is not open,


### PR DESCRIPTION
Currently, one can only find them hidden in GitHub issues and I think they are very useful.