### PR TITLE
Fix rbind_pages issue with named list argument

### DIFF
--- a/R/rbind_pages.R
+++ b/R/rbind_pages.R
@@ -49,7 +49,7 @@ rbind_pages <- function(pages){
 
   # Extract data frame column names
   dfdf <- lapply(pages, vapply, is.data.frame, logical(1))
-  dfnames <- unique(names(which(unlist(dfdf))))
+  dfnames <- unique(names(which(unlist(unname(dfdf)))))
 
   # No sub data frames
   if(!length(dfnames)){

--- a/tests/testthat/test_rbind_pages-names.R
+++ b/tests/testthat/test_rbind_pages-names.R
@@ -1,0 +1,19 @@
+context("rbind_pages")
+
+options(stringsAsFactors=FALSE)
+
+test_that("handles named list argument", {
+  x <- data.frame(foo = c(1:2))
+  x$bar = data.frame(name = c("jeroen", "eli"),
+                     age  = c(28, 24))
+  x  <- rep(list(x), 4)
+  xn <- setNames(x, letters[1:4])
+
+  expect_equal(rbind_pages(xn), rbind_pages(x))
+  expect_false(all(is.na(rbind_pages(xn)$bar)))
+})
+
+
+
+
+


### PR DESCRIPTION
`rbind_pages` failed for a named list argument where the argument had a `data.frame` column. In this case, the default behavior of `unlist` is to concatenate the list names with the `data.frame` names and these no longer can be used to index the `data.frame`.