### PR TITLE
Enhancement/make unique 

### DIFF
--- a/R/cleannames.R
+++ b/R/cleannames.R
@@ -4,5 +4,5 @@ cleannames <- function(objnames, no_dots = FALSE){
   objnames[is_missing] <- as.character(seq_len(length(objnames)))[is_missing]
   if(isTRUE(no_dots))
     objnames <- gsub(".", "_", objnames, fixed = TRUE)
-  make.unique(objnames)
+  make.unique(objnames, sep = "_")
 }

--- a/R/simplifyDataFrame.R
+++ b/R/simplifyDataFrame.R
@@ -72,7 +72,7 @@ simplifyDataFrame <- function(recordlist, columns, flatten, simplifyMatrix) {
     if(any(duplicated(rn))){
       warning('Duplicate names in "_row" field. Data frames must have unique row names.', call. = FALSE)
       if(is.character(rn)) {
-        row.names(columnlist)  <- make.unique(rn)
+        row.names(columnlist)  <- make.unique(rn, sep = "_")
       } else {
         row.names(columnlist) <- seq_len(n)
       }


### PR DESCRIPTION
Many of us in the community use jsonlite to help us get complex structures written to mongo stores. Since there is no support in the mongolite package to set `check.names` to false when inserting (and also for the sake of best practices) I believe this PR should be merged into a future release. 

This will on, duplicate key names, use an underscore notation instead of the default dot notation