### PR TITLE
Convert documentation to Markdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,3 +31,4 @@ Suggests:
     sf
 RoxygenNote: 7.1.1
 Encoding: UTF-8
+Roxygen: list(markdown = TRUE)

--- a/R/base64.R
+++ b/R/base64.R
@@ -1,8 +1,8 @@
 #' Encode/decode base64
 #'
 #' Simple in-memory base64 encoder and decoder. Used internally for converting
-#' raw vectors to text. Interchangeable with encoder from \code{base64enc} or
-#' \code{openssl} package.
+#' raw vectors to text. Interchangeable with encoder from `base64enc` or
+#' `openssl` package.
 #'
 #' @param input string or raw vector to be encoded/decoded
 #' @export

--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -1,18 +1,18 @@
 #' These functions are used to convert between JSON data and \R{} objects. The \code{\link{toJSON}} and \code{\link{fromJSON}}
-#' functions use a class based mapping, which follows conventions outlined in this paper:  \url{https://arxiv.org/abs/1403.2805} (also available as vignette).
+#' functions use a class based mapping, which follows conventions outlined in this paper:  <https://arxiv.org/abs/1403.2805> (also available as vignette).
 #'
 #' The \code{\link{toJSON}} and \code{\link{fromJSON}} functions are drop-in replacements for the identically named functions
-#' in packages \code{rjson} and \code{RJSONIO}. Our implementation uses an alternative, somewhat more consistent mapping
+#' in packages `rjson` and `RJSONIO`. Our implementation uses an alternative, somewhat more consistent mapping
 #' between \R{} objects and JSON strings.
 #'
 #' The \code{\link{serializeJSON}} and \code{\link{unserializeJSON}} functions in this package use an
 #' alternative system to convert between \R{} objects and JSON, which supports more classes but is much more verbose.
 #'
-#' A JSON string is always unicode, using \code{UTF-8} by default, hence there is usually no need to escape any characters.
+#' A JSON string is always unicode, using `UTF-8` by default, hence there is usually no need to escape any characters.
 #' However, the JSON format does support escaping of unicode characters, which are encoded using a backslash followed by
-#' a lower case \code{"u"} and 4 hex characters, for example: \code{"Z\\u00FCrich"}. The \code{fromJSON} function
+#' a lower case `"u"` and 4 hex characters, for example: `"Z\u00FCrich"`. The `fromJSON` function
 #' will parse such escape sequences but it is usually preferable to encode unicode characters in JSON using native
-#' \code{UTF-8} rather than escape sequences.
+#' `UTF-8` rather than escape sequences.
 #
 #' @rdname fromJSON
 #' @title Convert \R{} objects to/from JSON
@@ -35,12 +35,12 @@
 #' @param null how to encode NULL values within a list: must be one of 'null' or 'list'
 #' @param na how to print NA values: must be one of 'null' or 'string'. Defaults are class specific
 #' @param auto_unbox automatically \code{\link{unbox}} all atomic vectors of length 1. It is usually safer to avoid this and instead use the \code{\link{unbox}} function to unbox individual elements.
-#'   An exception is that objects of class \code{AsIs} (i.e. wrapped in \code{I()}) are not automatically unboxed. This is a way to mark single values as length-1 arrays.
-#' @param digits max number of decimal digits to print for numeric values. Use \code{I()} to specify significant digits. Use \code{NA} for max precision.
+#'   An exception is that objects of class `AsIs` (i.e. wrapped in `I()`) are not automatically unboxed. This is a way to mark single values as length-1 arrays.
+#' @param digits max number of decimal digits to print for numeric values. Use `I()` to specify significant digits. Use `NA` for max precision.
 #' @param force unclass/skip objects of classes with no defined JSON mapping
 #' @param pretty adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}
-#' @param ... arguments passed on to class specific \code{print} methods
-#' @references Jeroen Ooms (2014). The \code{jsonlite} Package: A Practical and Consistent Mapping Between JSON Data and \R{} Objects. \emph{arXiv:1403.2805}. \url{https://arxiv.org/abs/1403.2805}
+#' @param ... arguments passed on to class specific `print` methods
+#' @references Jeroen Ooms (2014). The `jsonlite` Package: A Practical and Consistent Mapping Between JSON Data and \R{} Objects. *arXiv:1403.2805*. <https://arxiv.org/abs/1403.2805>
 #' @seealso \code{\link{read_json}}, \code{\link{stream_in}}
 #' @examples # Stringify some data
 #' jsoncars <- toJSON(mtcars, pretty=TRUE)

--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -1,11 +1,11 @@
-#' These functions are used to convert between JSON data and \R{} objects. The \code{\link{toJSON}} and \code{\link{fromJSON}}
+#' These functions are used to convert between JSON data and \R{} objects. The [toJSON()] and [fromJSON()]
 #' functions use a class based mapping, which follows conventions outlined in this paper:  <https://arxiv.org/abs/1403.2805> (also available as vignette).
 #'
-#' The \code{\link{toJSON}} and \code{\link{fromJSON}} functions are drop-in replacements for the identically named functions
+#' The [toJSON()] and [fromJSON()] functions are drop-in replacements for the identically named functions
 #' in packages `rjson` and `RJSONIO`. Our implementation uses an alternative, somewhat more consistent mapping
 #' between \R{} objects and JSON strings.
 #'
-#' The \code{\link{serializeJSON}} and \code{\link{unserializeJSON}} functions in this package use an
+#' The [serializeJSON()] and [unserializeJSON()] functions in this package use an
 #' alternative system to convert between \R{} objects and JSON, which supports more classes but is much more verbose.
 #'
 #' A JSON string is always unicode, using `UTF-8` by default, hence there is usually no need to escape any characters.
@@ -23,7 +23,7 @@
 #' @param simplifyVector coerce JSON arrays containing only primitives into an atomic vector
 #' @param simplifyDataFrame coerce JSON arrays containing only records (JSON objects) into a data frame
 #' @param simplifyMatrix coerce JSON arrays containing vectors of equal mode and dimension into matrix or array
-#' @param flatten automatically \code{\link{flatten}} nested data frames into a single non-nested data frame
+#' @param flatten automatically [flatten()] nested data frames into a single non-nested data frame
 #' @param x the object to be encoded
 #' @param dataframe how to encode data.frame objects: must be one of 'rows', 'columns' or 'values'
 #' @param matrix how to encode matrices and higher dimensional arrays: must be one of 'rowmajor' or 'columnmajor'.
@@ -34,14 +34,14 @@
 #' @param raw how to encode raw objects: must be one of 'base64', 'hex' or 'mongo'
 #' @param null how to encode NULL values within a list: must be one of 'null' or 'list'
 #' @param na how to print NA values: must be one of 'null' or 'string'. Defaults are class specific
-#' @param auto_unbox automatically \code{\link{unbox}} all atomic vectors of length 1. It is usually safer to avoid this and instead use the \code{\link{unbox}} function to unbox individual elements.
-#'   An exception is that objects of class `AsIs` (i.e. wrapped in `I()`) are not automatically unboxed. This is a way to mark single values as length-1 arrays.
-#' @param digits max number of decimal digits to print for numeric values. Use `I()` to specify significant digits. Use `NA` for max precision.
+#' @param auto_unbox automatically [unbox()] all atomic vectors of length 1. It is usually safer to avoid this and instead use the [unbox()] function to unbox individual elements.
+#'   An exception is that objects of class `AsIs` (i.e. wrapped in [I()]) are not automatically unboxed. This is a way to mark single values as length-1 arrays.
+#' @param digits max number of decimal digits to print for numeric values. Use [I()] to specify significant digits. Use `NA` for max precision.
 #' @param force unclass/skip objects of classes with no defined JSON mapping
-#' @param pretty adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}
+#' @param pretty adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See [prettify()]
 #' @param ... arguments passed on to class specific `print` methods
 #' @references Jeroen Ooms (2014). The `jsonlite` Package: A Practical and Consistent Mapping Between JSON Data and \R{} Objects. *arXiv:1403.2805*. <https://arxiv.org/abs/1403.2805>
-#' @seealso \code{\link{read_json}}, \code{\link{stream_in}}
+#' @seealso [read_json()], [stream_in()]
 #' @examples # Stringify some data
 #' jsoncars <- toJSON(mtcars, pretty=TRUE)
 #' cat(jsoncars)

--- a/R/rbind_pages.R
+++ b/R/rbind_pages.R
@@ -1,24 +1,24 @@
 #' Combine pages into a single data frame
 #'
-#' The \code{rbind_pages} function is used to combine a list of data frames into a single
+#' The `rbind_pages` function is used to combine a list of data frames into a single
 #' data frame. This is often needed when working with a JSON API that limits the amount
 #' of data per request. If we need more data than what fits in a single request, we need to
 #' perform multiple requests that each retrieve a fragment of data, not unlike pages in a
-#' book. In practice this is often implemented using a \code{page} parameter in the API. The
-#' \code{rbind_pages} function can be used to combine these pages back into a single dataset.
+#' book. In practice this is often implemented using a `page` parameter in the API. The
+#' `rbind_pages` function can be used to combine these pages back into a single dataset.
 #'
-#' The \code{rbind_pages} function uses \code{\link[vctrs:vec_rbind]{vctrs::vec_rbind}}
+#' The `rbind_pages` function uses \code{\link[vctrs:vec_rbind]{vctrs::vec_rbind}}
 #' to bind the pages together. This generalizes \code{\link[base:cbind]{base::rbind}} in two
 #' ways:
 #'
 #' \itemize{
 #'   \item Not each column has to be present in each of the individual data frames; missing
-#'   columns will be filled up in \code{NA} values.
+#'   columns will be filled up in `NA` values.
 #'   \item Data frames can be nested (can contain other data frames).
 #' }
 #'
 #' @export
-#' @param pages a list of data frames, each representing a \emph{page} of data
+#' @param pages a list of data frames, each representing a *page* of data
 #' @examples # Basic example
 #' x <- data.frame(foo = rnorm(3), bar = c(TRUE, FALSE, TRUE))
 #' y <- data.frame(foo = rnorm(2), col = c("blue", "red"))

--- a/R/rbind_pages.R
+++ b/R/rbind_pages.R
@@ -7,8 +7,8 @@
 #' book. In practice this is often implemented using a `page` parameter in the API. The
 #' `rbind_pages` function can be used to combine these pages back into a single dataset.
 #'
-#' The `rbind_pages` function uses \code{\link[vctrs:vec_rbind]{vctrs::vec_rbind}}
-#' to bind the pages together. This generalizes \code{\link[base:cbind]{base::rbind}} in two
+#' The `rbind_pages` function uses [vctrs::vec_rbind()]
+#' to bind the pages together. This generalizes [`base::rbind()`][base::cbind] in two
 #' ways:
 #'
 #' \itemize{

--- a/R/rbind_pages.R
+++ b/R/rbind_pages.R
@@ -11,11 +11,9 @@
 #' to bind the pages together. This generalizes [`base::rbind()`][base::cbind] in two
 #' ways:
 #'
-#' \itemize{
-#'   \item Not each column has to be present in each of the individual data frames; missing
+#' - Not each column has to be present in each of the individual data frames; missing
 #'   columns will be filled up in `NA` values.
-#'   \item Data frames can be nested (can contain other data frames).
-#' }
+#' - Data frames can be nested (can contain other data frames).
 #'
 #' @export
 #' @param pages a list of data frames, each representing a *page* of data

--- a/R/read_json.R
+++ b/R/read_json.R
@@ -1,14 +1,14 @@
 #' Read/write JSON
 #'
-#' These functions are similar to \link{toJSON} and \link{fromJSON} except they
+#' These functions are similar to [toJSON()] and [fromJSON()] except they
 #' explicitly distinguish between path and literal input, and do not simplify
 #' by default.
 #'
 #' @export
 #' @rdname read_json
 #' @param path file on disk
-#' @param simplifyVector simplifies nested lists into vectors and data frames. See \link{fromJSON}.
-#' @seealso \code{\link{fromJSON}}, \code{\link{stream_in}}
+#' @param simplifyVector simplifies nested lists into vectors and data frames. See [fromJSON()].
+#' @seealso [fromJSON()], [stream_in()]
 #' @examples tmp <- tempfile()
 #' write_json(iris, tmp)
 #'
@@ -31,7 +31,7 @@ parse_json <- function(json, simplifyVector = FALSE, ...){
 #' @export
 #' @rdname read_json
 #' @param x an object to be serialized to JSON
-#' @param ... additional conversion arguments, see also \link{toJSON} or \link{fromJSON}
+#' @param ... additional conversion arguments, see also [toJSON()] or [fromJSON()]
 write_json <- function(x, path, ...) {
   json <- jsonlite::toJSON(x, ...)
   writeLines(json, path, useBytes = TRUE)

--- a/R/serializeJSON.R
+++ b/R/serializeJSON.R
@@ -41,7 +41,7 @@ serializeJSON <- function(x, digits = 8, pretty = FALSE) {
   return(ans)
 }
 
-#' @param txt a JSON string which was created using \code{serializeJSON}
+#' @param txt a JSON string which was created using `serializeJSON`
 #' @rdname serializeJSON
 unserializeJSON <- function(txt) {
   unpack(parseJSON(txt))

--- a/R/serializeJSON.R
+++ b/R/serializeJSON.R
@@ -1,6 +1,6 @@
-#' The \code{\link{serializeJSON}} and \code{\link{unserializeJSON}} functions convert between
+#' The [serializeJSON()] and [unserializeJSON()] functions convert between
 #' \R{} objects to JSON data. Instead of using a class based mapping like
-#' \code{\link{toJSON}} and \code{\link{fromJSON}}, the serialize functions base the encoding
+#' [toJSON()] and [fromJSON()], the serialize functions base the encoding
 #' schema on the storage type, and capture all data and attributes from any object.
 #' Thereby the object can be restored almost perfectly from its JSON representation, but
 #' the resulting JSON output is very verbose. Apart from environments, all standard storage
@@ -12,7 +12,7 @@
 #' @export serializeJSON unserializeJSON
 #' @param x an \R{} object to be serialized
 #' @param digits max number of digits (after the dot) to print for numeric values
-#' @param pretty add indentation/whitespace to JSON output. See \code{\link{prettify}}
+#' @param pretty add indentation/whitespace to JSON output. See [prettify()]
 #' @note JSON is a text based format which leads to loss of precision when printing numbers.
 #' @examples jsoncars <- serializeJSON(mtcars)
 #' mtcars2 <- unserializeJSON(jsoncars)

--- a/R/stream.R
+++ b/R/stream.R
@@ -1,9 +1,9 @@
 #' Streaming JSON input/output
 #'
 #' The `stream_in` and `stream_out` functions implement line-by-line processing
-#' of JSON data over a \code{\link{connection}}, such as a socket, url, file or pipe. JSON
+#' of JSON data over a [connection], such as a socket, url, file or pipe. JSON
 #' streaming requires the [ndjson](http://ndjson.org) format, which slightly differs
-#' from \code{\link{fromJSON}} and \code{\link{toJSON}}, see details.
+#' from [fromJSON()] and [toJSON()], see details.
 #'
 #' Because parsing huge JSON strings is difficult and inefficient, JSON streaming is done
 #' using **lines of minified JSON records**, a.k.a. [ndjson](http://ndjson.org).
@@ -12,7 +12,7 @@
 #' total stream combined is not valid JSON itself; only the individual lines are. Also note
 #' that because line-breaks are used as separators, prettified JSON is not permitted: the
 #' JSON lines *must* be minified. In this respect, the format is a bit different from
-#' \code{\link{fromJSON}} and \code{\link{toJSON}} where all lines are part of a single JSON
+#' [fromJSON()] and [toJSON()] where all lines are part of a single JSON
 #' structure with optional line breaks.
 #'
 #' The `handler` is a callback function which is called for each page (batch) of
@@ -27,7 +27,7 @@
 #' unlimited amount of data. See example.
 #'
 #' Note that a vector of JSON strings already in R can parsed with `stream_in` by
-#' creating a connection to it with \code{\link{textConnection}}.
+#' creating a connection to it with [textConnection()].
 #'
 #' If a connection is not opened yet, `stream_in` and `stream_out`
 #' will automatically open and later close the connection. Because R destroys connections
@@ -35,7 +35,7 @@
 #' calls to `stream_in` or `stream_out`, it needs to be opened
 #' beforehand. See example.
 #'
-#' @param con a \code{\link{connection}} object. If the connection is not open,
+#' @param con a [connection] object. If the connection is not open,
 #' `stream_in` and `stream_out` will automatically open
 #' and later close (and destroy) the connection. See details.
 #' @param handler a custom function that is called on each page of JSON data. If not specified,
@@ -44,14 +44,14 @@
 #' @param x object to be streamed out. Currently only data frames are supported.
 #' @param pagesize number of lines to read/write from/to the connection per iteration.
 #' @param verbose print some information on what is going on.
-#' @param ... arguments for \code{\link{fromJSON}} and \code{\link{toJSON}} that
+#' @param ... arguments for [fromJSON()] and [toJSON()] that
 #' control JSON formatting/parsing where applicable. Use with caution.
 #' @name stream_in, stream_out
 #' @export stream_in stream_out
 #' @rdname stream_in
 #' @references MongoDB export format: <https://docs.mongodb.com/manual/reference/program/mongoexport/>
 #' @references Documentation for the JSON Lines text file format: <https://jsonlines.org/>
-#' @seealso \code{\link{fromJSON}}, \code{\link{read_json}}
+#' @seealso [fromJSON()], [read_json()]
 #' @return The `stream_out` function always returns `NULL`.
 #' When no custom handler is specified, `stream_in` returns a data frame of all pages binded together.
 #' When a custom handler function is specified, `stream_in` always returns `NULL`.

--- a/R/stream.R
+++ b/R/stream.R
@@ -1,46 +1,46 @@
 #' Streaming JSON input/output
 #'
-#' The \code{stream_in} and \code{stream_out} functions implement line-by-line processing
+#' The `stream_in` and `stream_out` functions implement line-by-line processing
 #' of JSON data over a \code{\link{connection}}, such as a socket, url, file or pipe. JSON
-#' streaming requires the \href{http://ndjson.org}{ndjson} format, which slightly differs
+#' streaming requires the [ndjson](http://ndjson.org) format, which slightly differs
 #' from \code{\link{fromJSON}} and \code{\link{toJSON}}, see details.
 #'
 #' Because parsing huge JSON strings is difficult and inefficient, JSON streaming is done
-#' using \strong{lines of minified JSON records}, a.k.a. \href{http://ndjson.org}{ndjson}.
-#' This is pretty standard: JSON databases such as \href{https://github.com/datproject/dat}{dat}
+#' using **lines of minified JSON records**, a.k.a. [ndjson](http://ndjson.org).
+#' This is pretty standard: JSON databases such as [dat](https://github.com/datproject/dat)
 #' or MongoDB use the same format to import/export datasets. Note that this means that the
 #' total stream combined is not valid JSON itself; only the individual lines are. Also note
 #' that because line-breaks are used as separators, prettified JSON is not permitted: the
-#' JSON lines \emph{must} be minified. In this respect, the format is a bit different from
+#' JSON lines *must* be minified. In this respect, the format is a bit different from
 #' \code{\link{fromJSON}} and \code{\link{toJSON}} where all lines are part of a single JSON
 #' structure with optional line breaks.
 #'
-#' The \code{handler} is a callback function which is called for each page (batch) of
-#' JSON data with exactly one argument (usually a data frame with \code{pagesize} rows).
-#' If \code{handler} is missing or \code{NULL}, a default handler is used which stores all
+#' The `handler` is a callback function which is called for each page (batch) of
+#' JSON data with exactly one argument (usually a data frame with `pagesize` rows).
+#' If `handler` is missing or `NULL`, a default handler is used which stores all
 #' intermediate pages of data, and at the very end binds all pages together into one single
-#' data frame that is returned by \code{stream_in}. When a custom \code{handler} function
-#' is specified, \code{stream_in} does not store any intermediate results and always returns
-#' \code{NULL}. It is then up to the \code{handler} to process or store data pages.
-#' A \code{handler} function that does not store intermediate results in memory (for
+#' data frame that is returned by `stream_in`. When a custom `handler` function
+#' is specified, `stream_in` does not store any intermediate results and always returns
+#' `NULL`. It is then up to the `handler` to process or store data pages.
+#' A `handler` function that does not store intermediate results in memory (for
 #' example by writing output to another connection) results in a pipeline that can process an
 #' unlimited amount of data. See example.
 #'
-#' Note that a vector of JSON strings already in R can parsed with \code{stream_in} by
+#' Note that a vector of JSON strings already in R can parsed with `stream_in` by
 #' creating a connection to it with \code{\link{textConnection}}.
 #'
-#' If a connection is not opened yet, \code{stream_in} and \code{stream_out}
+#' If a connection is not opened yet, `stream_in` and `stream_out`
 #' will automatically open and later close the connection. Because R destroys connections
 #' when they are closed, they cannot be reused. To use a single connection for multiple
-#' calls to \code{stream_in} or \code{stream_out}, it needs to be opened
+#' calls to `stream_in` or `stream_out`, it needs to be opened
 #' beforehand. See example.
 #'
 #' @param con a \code{\link{connection}} object. If the connection is not open,
-#' \code{stream_in} and \code{stream_out} will automatically open
+#' `stream_in` and `stream_out` will automatically open
 #' and later close (and destroy) the connection. See details.
 #' @param handler a custom function that is called on each page of JSON data. If not specified,
 #' the default handler stores all pages and binds them into a single data frame that will be
-#' returned by \code{stream_in}. See details.
+#' returned by `stream_in`. See details.
 #' @param x object to be streamed out. Currently only data frames are supported.
 #' @param pagesize number of lines to read/write from/to the connection per iteration.
 #' @param verbose print some information on what is going on.
@@ -49,12 +49,12 @@
 #' @name stream_in, stream_out
 #' @export stream_in stream_out
 #' @rdname stream_in
-#' @references MongoDB export format: \url{https://docs.mongodb.com/manual/reference/program/mongoexport/}
-#' @references Documentation for the JSON Lines text file format: \url{https://jsonlines.org/}
+#' @references MongoDB export format: <https://docs.mongodb.com/manual/reference/program/mongoexport/>
+#' @references Documentation for the JSON Lines text file format: <https://jsonlines.org/>
 #' @seealso \code{\link{fromJSON}}, \code{\link{read_json}}
-#' @return The \code{stream_out} function always returns \code{NULL}.
-#' When no custom handler is specified, \code{stream_in} returns a data frame of all pages binded together.
-#' When a custom handler function is specified, \code{stream_in} always returns \code{NULL}.
+#' @return The `stream_out` function always returns `NULL`.
+#' When no custom handler is specified, `stream_in` returns a data frame of all pages binded together.
+#' When a custom handler function is specified, `stream_in` always returns `NULL`.
 #' @examples # compare formats
 #' x <- iris[1:3,]
 #' toJSON(x)
@@ -195,7 +195,7 @@ post_process <- function(x, simplifyVector = TRUE, simplifyDataFrame = simplifyV
 }
 
 #' @rdname stream_in
-#' @param prefix string to write before each line (use \code{"\u001e"} to write rfc7464 text sequences)
+#' @param prefix string to write before each line (use `"\u001e"` to write rfc7464 text sequences)
 stream_out <- function(x, con = stdout(), pagesize = 500, verbose = TRUE, prefix = "", ...) {
 
   if(!is(con, "connection")){

--- a/R/unbox.R
+++ b/R/unbox.R
@@ -1,11 +1,11 @@
 #' Unbox a vector or data frame
 #'
 #' This function marks an atomic vector or data frame as a
-#' \href{https://en.wikipedia.org/wiki/Singleton_(mathematics)}{singleton}, i.e.
+#' [singleton](https://en.wikipedia.org/wiki/Singleton_(mathematics)), i.e.
 #' a set with exactly 1 element. Thereby, the value will not turn into an
-#' \code{array} when encoded into JSON. This can only be done for
+#' `array` when encoded into JSON. This can only be done for
 #' atomic vectors of length 1, or data frames with exactly 1 row. To automatically
-#' unbox all vectors of length 1 within an object, use the \code{auto_unbox} argument
+#' unbox all vectors of length 1 within an object, use the `auto_unbox` argument
 #'in \code{\link{toJSON}}.
 #'
 #' It is usually recommended to avoid this function and stick with the default
@@ -13,12 +13,12 @@
 #' is if you are bound to some specific predefined JSON structure (e.g. to
 #' submit to an API), which has no natural \R{} representation. Note that the default
 #' encoding for data frames naturally results in a collection of key-value pairs,
-#' without using \code{unbox}.
+#' without using `unbox`.
 #'
 #' @param x atomic vector of length 1, or data frame with 1 row.
-#' @return Returns a singleton version of \code{x}.
+#' @return Returns a singleton version of `x`.
 #' @export
-#' @references \url{https://en.wikipedia.org/wiki/Singleton_(mathematics)}
+#' @references <https://en.wikipedia.org/wiki/Singleton_(mathematics)>
 #' @examples toJSON(list(foo=123))
 #' toJSON(list(foo=unbox(123)))
 #'

--- a/R/unbox.R
+++ b/R/unbox.R
@@ -6,7 +6,7 @@
 #' `array` when encoded into JSON. This can only be done for
 #' atomic vectors of length 1, or data frames with exactly 1 row. To automatically
 #' unbox all vectors of length 1 within an object, use the `auto_unbox` argument
-#'in \code{\link{toJSON}}.
+#' in [toJSON()].
 #'
 #' It is usually recommended to avoid this function and stick with the default
 #' encoding schema for the various \R{} classes. The only use case for this function

--- a/man/fromJSON.Rd
+++ b/man/fromJSON.Rd
@@ -43,7 +43,7 @@ toJSON(
 
 \item{simplifyMatrix}{coerce JSON arrays containing vectors of equal mode and dimension into matrix or array}
 
-\item{flatten}{automatically \code{\link{flatten}} nested data frames into a single non-nested data frame}
+\item{flatten}{automatically \code{\link[=flatten]{flatten()}} nested data frames into a single non-nested data frame}
 
 \item{...}{arguments passed on to class specific \code{print} methods}
 
@@ -67,25 +67,25 @@ toJSON(
 
 \item{na}{how to print NA values: must be one of 'null' or 'string'. Defaults are class specific}
 
-\item{auto_unbox}{automatically \code{\link{unbox}} all atomic vectors of length 1. It is usually safer to avoid this and instead use the \code{\link{unbox}} function to unbox individual elements.
-An exception is that objects of class \code{AsIs} (i.e. wrapped in \code{I()}) are not automatically unboxed. This is a way to mark single values as length-1 arrays.}
+\item{auto_unbox}{automatically \code{\link[=unbox]{unbox()}} all atomic vectors of length 1. It is usually safer to avoid this and instead use the \code{\link[=unbox]{unbox()}} function to unbox individual elements.
+An exception is that objects of class \code{AsIs} (i.e. wrapped in \code{\link[=I]{I()}}) are not automatically unboxed. This is a way to mark single values as length-1 arrays.}
 
-\item{digits}{max number of decimal digits to print for numeric values. Use \code{I()} to specify significant digits. Use \code{NA} for max precision.}
+\item{digits}{max number of decimal digits to print for numeric values. Use \code{\link[=I]{I()}} to specify significant digits. Use \code{NA} for max precision.}
 
-\item{pretty}{adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link{prettify}}}
+\item{pretty}{adds indentation whitespace to JSON output. Can be TRUE/FALSE or a number specifying the number of spaces to indent. See \code{\link[=prettify]{prettify()}}}
 
 \item{force}{unclass/skip objects of classes with no defined JSON mapping}
 }
 \description{
-These functions are used to convert between JSON data and \R{} objects. The \code{\link{toJSON}} and \code{\link{fromJSON}}
+These functions are used to convert between JSON data and \R{} objects. The \code{\link[=toJSON]{toJSON()}} and \code{\link[=fromJSON]{fromJSON()}}
 functions use a class based mapping, which follows conventions outlined in this paper:  \url{https://arxiv.org/abs/1403.2805} (also available as vignette).
 }
 \details{
-The \code{\link{toJSON}} and \code{\link{fromJSON}} functions are drop-in replacements for the identically named functions
+The \code{\link[=toJSON]{toJSON()}} and \code{\link[=fromJSON]{fromJSON()}} functions are drop-in replacements for the identically named functions
 in packages \code{rjson} and \code{RJSONIO}. Our implementation uses an alternative, somewhat more consistent mapping
 between \R{} objects and JSON strings.
 
-The \code{\link{serializeJSON}} and \code{\link{unserializeJSON}} functions in this package use an
+The \code{\link[=serializeJSON]{serializeJSON()}} and \code{\link[=unserializeJSON]{unserializeJSON()}} functions in this package use an
 alternative system to convert between \R{} objects and JSON, which supports more classes but is much more verbose.
 
 A JSON string is always unicode, using \code{UTF-8} by default, hence there is usually no need to escape any characters.
@@ -133,5 +133,5 @@ identical(data3, flatten(data2))
 Jeroen Ooms (2014). The \code{jsonlite} Package: A Practical and Consistent Mapping Between JSON Data and \R{} Objects. \emph{arXiv:1403.2805}. \url{https://arxiv.org/abs/1403.2805}
 }
 \seealso{
-\code{\link{read_json}}, \code{\link{stream_in}}
+\code{\link[=read_json]{read_json()}}, \code{\link[=stream_in]{stream_in()}}
 }

--- a/man/rbind_pages.Rd
+++ b/man/rbind_pages.Rd
@@ -23,9 +23,9 @@ to bind the pages together. This generalizes \code{\link[base:cbind]{base::rbind
 ways:
 
 \itemize{
-  \item Not each column has to be present in each of the individual data frames; missing
-  columns will be filled up in \code{NA} values.
-  \item Data frames can be nested (can contain other data frames).
+\item Not each column has to be present in each of the individual data frames; missing
+columns will be filled up in \code{NA} values.
+\item Data frames can be nested (can contain other data frames).
 }
 }
 \examples{

--- a/man/rbind_pages.Rd
+++ b/man/rbind_pages.Rd
@@ -18,8 +18,8 @@ book. In practice this is often implemented using a \code{page} parameter in the
 \code{rbind_pages} function can be used to combine these pages back into a single dataset.
 }
 \details{
-The \code{rbind_pages} function uses \code{\link[vctrs:vec_rbind]{vctrs::vec_rbind}}
-to bind the pages together. This generalizes \code{\link[base:cbind]{base::rbind}} in two
+The \code{rbind_pages} function uses \code{\link[vctrs:vec_bind]{vctrs::vec_rbind()}}
+to bind the pages together. This generalizes \code{\link[base:cbind]{base::rbind()}} in two
 ways:
 
 \itemize{

--- a/man/read_json.Rd
+++ b/man/read_json.Rd
@@ -15,16 +15,16 @@ write_json(x, path, ...)
 \arguments{
 \item{path}{file on disk}
 
-\item{simplifyVector}{simplifies nested lists into vectors and data frames. See \link{fromJSON}.}
+\item{simplifyVector}{simplifies nested lists into vectors and data frames. See \code{\link[=fromJSON]{fromJSON()}}.}
 
-\item{...}{additional conversion arguments, see also \link{toJSON} or \link{fromJSON}}
+\item{...}{additional conversion arguments, see also \code{\link[=toJSON]{toJSON()}} or \code{\link[=fromJSON]{fromJSON()}}}
 
 \item{json}{string with literal json or connection object to read from}
 
 \item{x}{an object to be serialized to JSON}
 }
 \description{
-These functions are similar to \link{toJSON} and \link{fromJSON} except they
+These functions are similar to \code{\link[=toJSON]{toJSON()}} and \code{\link[=fromJSON]{fromJSON()}} except they
 explicitly distinguish between path and literal input, and do not simplify
 by default.
 }
@@ -39,5 +39,5 @@ read_json(tmp)
 read_json(tmp, simplifyVector = TRUE)
 }
 \seealso{
-\code{\link{fromJSON}}, \code{\link{stream_in}}
+\code{\link[=fromJSON]{fromJSON()}}, \code{\link[=stream_in]{stream_in()}}
 }

--- a/man/serializeJSON.Rd
+++ b/man/serializeJSON.Rd
@@ -14,14 +14,14 @@ unserializeJSON(txt)
 
 \item{digits}{max number of digits (after the dot) to print for numeric values}
 
-\item{pretty}{add indentation/whitespace to JSON output. See \code{\link{prettify}}}
+\item{pretty}{add indentation/whitespace to JSON output. See \code{\link[=prettify]{prettify()}}}
 
 \item{txt}{a JSON string which was created using \code{serializeJSON}}
 }
 \description{
-The \code{\link{serializeJSON}} and \code{\link{unserializeJSON}} functions convert between
+The \code{\link[=serializeJSON]{serializeJSON()}} and \code{\link[=unserializeJSON]{unserializeJSON()}} functions convert between
 \R{} objects to JSON data. Instead of using a class based mapping like
-\code{\link{toJSON}} and \code{\link{fromJSON}}, the serialize functions base the encoding
+\code{\link[=toJSON]{toJSON()}} and \code{\link[=fromJSON]{fromJSON()}}, the serialize functions base the encoding
 schema on the storage type, and capture all data and attributes from any object.
 Thereby the object can be restored almost perfectly from its JSON representation, but
 the resulting JSON output is very verbose. Apart from environments, all standard storage

--- a/man/stream_in.Rd
+++ b/man/stream_in.Rd
@@ -11,7 +11,7 @@ stream_in(con, handler = NULL, pagesize = 500, verbose = TRUE, ...)
 stream_out(x, con = stdout(), pagesize = 500, verbose = TRUE, prefix = "", ...)
 }
 \arguments{
-\item{con}{a \code{\link{connection}} object. If the connection is not open,
+\item{con}{a \link{connection} object. If the connection is not open,
 \code{stream_in} and \code{stream_out} will automatically open
 and later close (and destroy) the connection. See details.}
 
@@ -23,7 +23,7 @@ returned by \code{stream_in}. See details.}
 
 \item{verbose}{print some information on what is going on.}
 
-\item{...}{arguments for \code{\link{fromJSON}} and \code{\link{toJSON}} that
+\item{...}{arguments for \code{\link[=fromJSON]{fromJSON()}} and \code{\link[=toJSON]{toJSON()}} that
 control JSON formatting/parsing where applicable. Use with caution.}
 
 \item{x}{object to be streamed out. Currently only data frames are supported.}
@@ -37,9 +37,9 @@ When a custom handler function is specified, \code{stream_in} always returns \co
 }
 \description{
 The \code{stream_in} and \code{stream_out} functions implement line-by-line processing
-of JSON data over a \code{\link{connection}}, such as a socket, url, file or pipe. JSON
+of JSON data over a \link{connection}, such as a socket, url, file or pipe. JSON
 streaming requires the \href{http://ndjson.org}{ndjson} format, which slightly differs
-from \code{\link{fromJSON}} and \code{\link{toJSON}}, see details.
+from \code{\link[=fromJSON]{fromJSON()}} and \code{\link[=toJSON]{toJSON()}}, see details.
 }
 \details{
 Because parsing huge JSON strings is difficult and inefficient, JSON streaming is done
@@ -49,7 +49,7 @@ or MongoDB use the same format to import/export datasets. Note that this means t
 total stream combined is not valid JSON itself; only the individual lines are. Also note
 that because line-breaks are used as separators, prettified JSON is not permitted: the
 JSON lines \emph{must} be minified. In this respect, the format is a bit different from
-\code{\link{fromJSON}} and \code{\link{toJSON}} where all lines are part of a single JSON
+\code{\link[=fromJSON]{fromJSON()}} and \code{\link[=toJSON]{toJSON()}} where all lines are part of a single JSON
 structure with optional line breaks.
 
 The \code{handler} is a callback function which is called for each page (batch) of
@@ -64,7 +64,7 @@ example by writing output to another connection) results in a pipeline that can 
 unlimited amount of data. See example.
 
 Note that a vector of JSON strings already in R can parsed with \code{stream_in} by
-creating a connection to it with \code{\link{textConnection}}.
+creating a connection to it with \code{\link[=textConnection]{textConnection()}}.
 
 If a connection is not opened yet, \code{stream_in} and \code{stream_out}
 will automatically open and later close the connection. Because R destroys connections
@@ -144,5 +144,5 @@ MongoDB export format: \url{https://docs.mongodb.com/manual/reference/program/mo
 Documentation for the JSON Lines text file format: \url{https://jsonlines.org/}
 }
 \seealso{
-\code{\link{fromJSON}}, \code{\link{read_json}}
+\code{\link[=fromJSON]{fromJSON()}}, \code{\link[=read_json]{read_json()}}
 }

--- a/man/stream_in.Rd
+++ b/man/stream_in.Rd
@@ -28,7 +28,7 @@ control JSON formatting/parsing where applicable. Use with caution.}
 
 \item{x}{object to be streamed out. Currently only data frames are supported.}
 
-\item{prefix}{string to write before each line (use \code{"\u001e"} to write rfc7464 text sequences)}
+\item{prefix}{string to write before each line (use \code{"\\u001e"} to write rfc7464 text sequences)}
 }
 \value{
 The \code{stream_out} function always returns \code{NULL}.

--- a/man/unbox.Rd
+++ b/man/unbox.Rd
@@ -19,7 +19,7 @@ a set with exactly 1 element. Thereby, the value will not turn into an
 \code{array} when encoded into JSON. This can only be done for
 atomic vectors of length 1, or data frames with exactly 1 row. To automatically
 unbox all vectors of length 1 within an object, use the \code{auto_unbox} argument
-in \code{\link{toJSON}}.
+in \code{\link[=toJSON]{toJSON()}}.
 }
 \details{
 It is usually recommended to avoid this function and stick with the default


### PR DESCRIPTION
Commits correspond to individual scopes in `roxygen2md::roxygen2md()` .