### PR TITLE
fromJSON() supports functions in simplifyDataFrame argument

### DIFF
--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -21,7 +21,9 @@
 #' @export fromJSON toJSON
 #' @param txt a JSON string, URL or file
 #' @param simplifyVector coerce JSON arrays containing only primitives into an atomic vector
-#' @param simplifyDataFrame coerce JSON arrays containing only records (JSON objects) into a data frame
+#' @param simplifyDataFrame coerce JSON arrays containing only records (JSON objects) into a data frame.
+#'   Can be `TRUE`, `FALSE` or a function with one argument, e.g. `tibble::as_tibble`.
+#'   If a function, all simplified data fraees are postprocessed with that function.
 #' @param simplifyMatrix coerce JSON arrays containing vectors of equal mode and dimension into matrix or array
 #' @param flatten automatically [flatten()] nested data frames into a single non-nested data frame
 #' @param x the object to be encoded

--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -107,14 +107,6 @@ fromJSON <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVec
 parse_and_simplify <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVector,
   simplifyMatrix = simplifyVector, flatten = FALSE, unicode = TRUE, validate = TRUE, bigint_as_char = FALSE, ...){
 
-  # support function in simplifyDataFrame
-  # avoid rigorous argument checks for compatibility
-  if (isTRUE(simplifyDataFrame)) {
-    simplifyDataFrame <- identity
-  } else if (!is.function(simplifyDataFrame)) {
-    simplifyDataFrame <- NULL
-  }
-
   if(!missing(unicode)){
     message("Argument unicode has been deprecated. YAJL always parses unicode.")
   }
@@ -127,7 +119,7 @@ parse_and_simplify <- function(txt, simplifyVector = TRUE, simplifyDataFrame = s
   obj <- parseJSON(txt, bigint_as_char)
 
   # post processing
-  if (any(isTRUE(simplifyVector), !is.null(simplifyDataFrame), isTRUE(simplifyMatrix))) {
+  if (any(isTRUE(simplifyVector), isTRUE(simplifyDataFrame), isTRUE(simplifyMatrix))) {
     return(simplify(obj, simplifyVector = simplifyVector, simplifyDataFrame = simplifyDataFrame,
       simplifyMatrix = simplifyMatrix, flatten = flatten, ...))
   } else {

--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -105,6 +105,14 @@ fromJSON <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVec
 parse_and_simplify <- function(txt, simplifyVector = TRUE, simplifyDataFrame = simplifyVector,
   simplifyMatrix = simplifyVector, flatten = FALSE, unicode = TRUE, validate = TRUE, bigint_as_char = FALSE, ...){
 
+  # support function in simplifyDataFrame
+  # avoid rigorous argument checks for compatibility
+  if (isTRUE(simplifyDataFrame)) {
+    simplifyDataFrame <- identity
+  } else if (!is.function(simplifyDataFrame)) {
+    simplifyDataFrame <- NULL
+  }
+
   if(!missing(unicode)){
     message("Argument unicode has been deprecated. YAJL always parses unicode.")
   }
@@ -117,7 +125,7 @@ parse_and_simplify <- function(txt, simplifyVector = TRUE, simplifyDataFrame = s
   obj <- parseJSON(txt, bigint_as_char)
 
   # post processing
-  if (any(isTRUE(simplifyVector), isTRUE(simplifyDataFrame), isTRUE(simplifyMatrix))) {
+  if (any(isTRUE(simplifyVector), !is.null(simplifyDataFrame), isTRUE(simplifyMatrix))) {
     return(simplify(obj, simplifyVector = simplifyVector, simplifyDataFrame = simplifyDataFrame,
       simplifyMatrix = simplifyMatrix, flatten = flatten, ...))
   } else {

--- a/R/simplify.R
+++ b/R/simplify.R
@@ -13,7 +13,7 @@ simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplif
 
   # list can be a dataframe recordlist
   if (!is.null(simplifyDataFrame) && is.recordlist(x)) {
-    mydf <- coerceDataFrame(simplifyDataFrame(x, flatten = flatten, simplifyMatrix = simplifySubMatrix, simplifyDataFrame = simplifyDataFrame))
+    mydf <- coerceDataFrame(doSimplifyDataFrame(x, flatten = flatten, simplifyMatrix = simplifySubMatrix, simplifyDataFrame = simplifyDataFrame))
     if(isTRUE(simplifyDate) && is.data.frame(mydf) && is.datelist(mydf)){
       return(parse_date(mydf[["$date"]]))
     }

--- a/R/simplify.R
+++ b/R/simplify.R
@@ -1,4 +1,4 @@
-simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplifyMatrix = TRUE,
+simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = identity, simplifyMatrix = TRUE,
   simplifyDate = simplifyVector, homoList = TRUE, flatten = FALSE, columnmajor = FALSE,
   simplifySubMatrix = simplifyMatrix) {
 
@@ -8,8 +8,8 @@ simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplif
   }
 
   # list can be a dataframe recordlist
-  if (isTRUE(simplifyDataFrame) && is.recordlist(x)) {
-    mydf <- simplifyDataFrame(x, flatten = flatten, simplifyMatrix = simplifySubMatrix)
+  if (!is.null(simplifyDataFrame) && is.recordlist(x)) {
+    mydf <- simplifyDataFrame(simplifyDataFrame_(x, flatten = flatten, simplifyMatrix = simplifySubMatrix, simplifyDataFrame = simplifyDataFrame))
     if(isTRUE(simplifyDate) && is.data.frame(mydf) && is.datelist(mydf)){
       return(parse_date(mydf[["$date"]]))
     }
@@ -66,7 +66,7 @@ simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplif
       # if all the others look like data frames, coerse to data frames!
       if (all(vapply(out[!isemptylist], is.data.frame, logical(1)))) {
         for (i in which(isemptylist)) {
-        out[[i]] <- data.frame()
+          out[[i]] <- simplifyDataFrame(data.frame())
         }
         return(out)
       }

--- a/R/simplify.R
+++ b/R/simplify.R
@@ -7,17 +7,13 @@ simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplif
     return(x)
   }
 
-  # support function in simplifyDataFrame
-  # avoid rigorous argument checks for compatibility
-  if (isTRUE(simplifyDataFrame)) {
-    simplifyDataFrame <- identity
-  } else if (!is.function(simplifyDataFrame)) {
-    simplifyDataFrame <- NULL
-  }
+  # Input: `TRUE`, a function, or anything else
+  # Output: a function or `NULL`
+  coerceDataFrame <- getCoerceDataFrame(simplifyDataFrame)
 
   # list can be a dataframe recordlist
   if (!is.null(simplifyDataFrame) && is.recordlist(x)) {
-    mydf <- simplifyDataFrame(doSimplifyDataFrame(x, flatten = flatten, simplifyMatrix = simplifySubMatrix, simplifyDataFrame = simplifyDataFrame))
+    mydf <- coerceDataFrame(doSimplifyDataFrame(x, flatten = flatten, simplifyMatrix = simplifySubMatrix, simplifyDataFrame = simplifyDataFrame))
     if(isTRUE(simplifyDate) && is.data.frame(mydf) && is.datelist(mydf)){
       return(parse_date(mydf[["$date"]]))
     }
@@ -74,7 +70,7 @@ simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplif
       # if all the others look like data frames, coerse to data frames!
       if (all(vapply(out[!isemptylist], is.data.frame, logical(1)))) {
         for (i in which(isemptylist)) {
-          out[[i]] <- simplifyDataFrame(data.frame())
+          out[[i]] <- coerceDataFrame(data.frame())
         }
         return(out)
       }
@@ -98,6 +94,18 @@ simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplif
 
   # return object
   return(out)
+}
+
+getCoerceDataFrame <- function(simplifyDataFrame) {
+  # support function in simplifyDataFrame
+  # avoid rigorous argument checks for compatibility
+  if (isTRUE(simplifyDataFrame)) {
+    identity
+  } else if (is.function(simplifyDataFrame)) {
+    simplifyDataFrame
+  } else {
+    NULL
+  }
 }
 
 is.matrixlist <- function(x) {

--- a/R/simplify.R
+++ b/R/simplify.R
@@ -13,7 +13,7 @@ simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplif
 
   # list can be a dataframe recordlist
   if (!is.null(simplifyDataFrame) && is.recordlist(x)) {
-    mydf <- coerceDataFrame(doSimplifyDataFrame(x, flatten = flatten, simplifyMatrix = simplifySubMatrix, simplifyDataFrame = simplifyDataFrame))
+    mydf <- coerceDataFrame(simplifyDataFrame(x, flatten = flatten, simplifyMatrix = simplifySubMatrix, simplifyDataFrame = simplifyDataFrame))
     if(isTRUE(simplifyDate) && is.data.frame(mydf) && is.datelist(mydf)){
       return(parse_date(mydf[["$date"]]))
     }

--- a/R/simplify.R
+++ b/R/simplify.R
@@ -9,7 +9,7 @@ simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = identity, sim
 
   # list can be a dataframe recordlist
   if (!is.null(simplifyDataFrame) && is.recordlist(x)) {
-    mydf <- simplifyDataFrame(simplifyDataFrame_(x, flatten = flatten, simplifyMatrix = simplifySubMatrix, simplifyDataFrame = simplifyDataFrame))
+    mydf <- simplifyDataFrame(doSimplifyDataFrame(x, flatten = flatten, simplifyMatrix = simplifySubMatrix, simplifyDataFrame = simplifyDataFrame))
     if(isTRUE(simplifyDate) && is.data.frame(mydf) && is.datelist(mydf)){
       return(parse_date(mydf[["$date"]]))
     }

--- a/R/simplify.R
+++ b/R/simplify.R
@@ -1,10 +1,18 @@
-simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = identity, simplifyMatrix = TRUE,
+simplify <- function(x, simplifyVector = TRUE, simplifyDataFrame = TRUE, simplifyMatrix = TRUE,
   simplifyDate = simplifyVector, homoList = TRUE, flatten = FALSE, columnmajor = FALSE,
   simplifySubMatrix = simplifyMatrix) {
 
   #This includes '[]' and '{}')
   if (!is.list(x) || !length(x)) {
     return(x)
+  }
+
+  # support function in simplifyDataFrame
+  # avoid rigorous argument checks for compatibility
+  if (isTRUE(simplifyDataFrame)) {
+    simplifyDataFrame <- identity
+  } else if (!is.function(simplifyDataFrame)) {
+    simplifyDataFrame <- NULL
   }
 
   # list can be a dataframe recordlist

--- a/R/simplifyDataFrame.R
+++ b/R/simplifyDataFrame.R
@@ -1,4 +1,4 @@
-simplifyDataFrame <- function(recordlist, columns, flatten, simplifyMatrix) {
+simplifyDataFrame_ <- function(recordlist, columns, flatten, simplifyMatrix, simplifyDataFrame) {
 
   # no records at all
   if (!length(recordlist)) {
@@ -26,7 +26,7 @@ simplifyDataFrame <- function(recordlist, columns, flatten, simplifyMatrix) {
   columnlist <- transpose_list(recordlist, columns)
 
   # simplify vectors and nested data frames
-  columnlist <- lapply(columnlist, simplify, simplifyVector = TRUE, simplifyDataFrame = TRUE,
+  columnlist <- lapply(columnlist, simplify, simplifyVector = TRUE, simplifyDataFrame = simplifyDataFrame,
     simplifyMatrix = FALSE, simplifySubMatrix = simplifyMatrix, flatten = flatten)
 
   # check that all elements have equal length

--- a/R/simplifyDataFrame.R
+++ b/R/simplifyDataFrame.R
@@ -1,4 +1,4 @@
-simplifyDataFrame_ <- function(recordlist, columns, flatten, simplifyMatrix, simplifyDataFrame) {
+doSimplifyDataFrame <- function(recordlist, columns, flatten, simplifyMatrix, simplifyDataFrame) {
 
   # no records at all
   if (!length(recordlist)) {

--- a/R/simplifyDataFrame.R
+++ b/R/simplifyDataFrame.R
@@ -1,4 +1,4 @@
-simplifyDataFrame <- function(recordlist, columns, flatten, simplifyMatrix, simplifyDataFrame) {
+doSimplifyDataFrame <- function(recordlist, columns, flatten, simplifyMatrix, simplifyDataFrame) {
 
   # no records at all
   if (!length(recordlist)) {

--- a/R/simplifyDataFrame.R
+++ b/R/simplifyDataFrame.R
@@ -1,4 +1,4 @@
-doSimplifyDataFrame <- function(recordlist, columns, flatten, simplifyMatrix, simplifyDataFrame) {
+simplifyDataFrame <- function(recordlist, columns, flatten, simplifyMatrix, simplifyDataFrame) {
 
   # no records at all
   if (!length(recordlist)) {

--- a/R/stream.R
+++ b/R/stream.R
@@ -188,7 +188,7 @@ post_process <- function(x, simplifyVector = TRUE, simplifyDataFrame = simplifyV
 
   # We assume ndjson with objects
   if(!is.null(simplifyDataFrame)){
-    return(doSimplifyDataFrame(as.data.frame(out)))
+    return(simplifyDataFrame(as.data.frame(out)))
   } else {
     out
   }

--- a/R/stream.R
+++ b/R/stream.R
@@ -186,9 +186,11 @@ post_process <- function(x, simplifyVector = TRUE, simplifyDataFrame = simplifyV
   out <- simplify(x, simplifyVector = simplifyVector, simplifyDataFrame = simplifyDataFrame,
     simplifyMatrix = simplifyMatrix, flatten = flatten)
 
+  coerceDataFrame <- getCoerceDataFrame(simplifyDataFrame)
+
   # We assume ndjson with objects
-  if(!is.null(simplifyDataFrame)){
-    return(simplifyDataFrame(as.data.frame(out)))
+  if(!is.null(coerceDataFrame)){
+    return(coerceDataFrame(as.data.frame(out)))
   } else {
     out
   }

--- a/R/stream.R
+++ b/R/stream.R
@@ -186,10 +186,10 @@ post_process <- function(x, simplifyVector = TRUE, simplifyDataFrame = simplifyV
   out <- simplify(x, simplifyVector = simplifyVector, simplifyDataFrame = simplifyDataFrame,
     simplifyMatrix = simplifyMatrix, flatten = flatten)
 
-  coerceDataFrame <- getCoerceDataFrame(simplifyDataFrame)
-
   # We assume ndjson with objects
-  if(!is.null(coerceDataFrame)){
+  if(!isTRUE(simplifyDataFrame)){
+    coerceDataFrame <- getCoerceDataFrame(simplifyDataFrame)
+
     return(coerceDataFrame(as.data.frame(out)))
   } else {
     out

--- a/R/stream.R
+++ b/R/stream.R
@@ -187,8 +187,8 @@ post_process <- function(x, simplifyVector = TRUE, simplifyDataFrame = simplifyV
     simplifyMatrix = simplifyMatrix, flatten = flatten)
 
   # We assume ndjson with objects
-  if(isTRUE(simplifyDataFrame)){
-    return(as.data.frame(out))
+  if(!is.null(simplifyDataFrame)){
+    return(simplifyDataFrame(as.data.frame(out)))
   } else {
     out
   }

--- a/R/stream.R
+++ b/R/stream.R
@@ -188,7 +188,7 @@ post_process <- function(x, simplifyVector = TRUE, simplifyDataFrame = simplifyV
 
   # We assume ndjson with objects
   if(!is.null(simplifyDataFrame)){
-    return(simplifyDataFrame(as.data.frame(out)))
+    return(doSimplifyDataFrame(as.data.frame(out)))
   } else {
     out
   }

--- a/man/fromJSON.Rd
+++ b/man/fromJSON.Rd
@@ -39,7 +39,9 @@ toJSON(
 
 \item{simplifyVector}{coerce JSON arrays containing only primitives into an atomic vector}
 
-\item{simplifyDataFrame}{coerce JSON arrays containing only records (JSON objects) into a data frame}
+\item{simplifyDataFrame}{coerce JSON arrays containing only records (JSON objects) into a data frame.
+Can be \code{TRUE}, \code{FALSE} or a function with one argument, e.g. \code{tibble::as_tibble}.
+If a function, all simplified data fraees are postprocessed with that function.}
 
 \item{simplifyMatrix}{coerce JSON arrays containing vectors of equal mode and dimension into matrix or array}
 

--- a/stuff/fromBSON.R
+++ b/stuff/fromBSON.R
@@ -1,24 +1,24 @@
 #' Convert a mongo.bson object to an R object.
-#' 
+#'
 #' This function uses \code{mongo.bson.to.list} from the \code{rmongodb} package
 #' to read a \code{BSON} object, and then uses \code{jsonlite} the same mapping as for
-#' \code{JSON} objects to convert it into an R object. 
-#' 
+#' \code{JSON} objects to convert it into an R object.
+#'
 #' @param b A \code{mongo.bson} object. Passed to \code{mongo.bson.to.list}. See package \code{rmongodb}.
 #' @param simplifyVector coerse JSON arrays containing only scalars into a vector
 #' @param simplifyDataFrame coerse JSON arrays containing only records (JSON objects) into a data frame.
 #' @param simplifyMatrix coerse JSON arrays containing vectors of equal length and mode into matrix or array.
 #' @param ... arguments passed on to class specific \code{print} methods
 #' @export
-fromBSON <- function(b, simplifyVector = TRUE, simplifyDataFrame = simplifyVector, 
+fromBSON <- function(b, simplifyVector = TRUE, simplifyDataFrame = simplifyVector,
   simplifyMatrix = simplifyVector, ...){
-  
+
   #load rmongodb if not loaded
   obj <- rmongodb::mongo.bson.to.list(b)
-  
+
   # post processing
-  if (any(isTRUE(simplifyVector), isTRUE(simplifyDataFrame), isTRUE(simplifyMatrix))) {
-    return(simplify(obj, simplifyVector = simplifyVector, simplifyDataFrame = simplifyDataFrame, 
+  if (any(isTRUE(simplifyVector), !is.null(simplifyDataFrame), isTRUE(simplifyMatrix))) {
+    return(simplify(obj, simplifyVector = simplifyVector, simplifyDataFrame = simplifyDataFrame,
       simplifyMatrix = simplifyMatrix, ...))
   } else {
     return(obj)
@@ -31,7 +31,7 @@ mongoquery <- function(mongo, ns, ...){
   while (mongo.cursor.next(cursor)) {
     b <- mongo.cursor.value(cursor);
     results[[length(results)+1]] <- mongo.bson.to.list(b);
-  }  
+  }
   jsonlite:::simplify(results)
 }
 


### PR DESCRIPTION
Closes #356.

I made the change as minimal as possible, perhaps at the expense of clarity. Should the internal `simplifyToDataFrame` argument perhaps be renamed to `coerceDataFrame` or similar?