### PR TITLE
Fix error serializing S4 class extending SEXPTYPE for certain types.

### DIFF
--- a/R/pack.R
+++ b/R/pack.R
@@ -5,17 +5,6 @@ pack <- function(obj, ...) {
   # encode by storage mode
   encoding.mode <- typeof(obj)
 
-  # Strip off 'class' from S4 attributes
-  attrib <- attributes(obj)
-  if(isS4(obj)){
-    encoding.mode <- "S4"
-    if (".Data" %in% slotNames(obj)) {
-      attrib[[".Data"]] = obj@.Data
-    }
-    attrib <- attrib[slotNames(obj)]
-    names(attrib) <- slotNames(obj)
-  }
-
   # null may not have attributes
   if (encoding.mode == "NULL" || identical(obj, as.name('\001NULL\001'))) {
     return(list(type = as.scalar("NULL")))
@@ -29,6 +18,17 @@ pack <- function(obj, ...) {
   # special exception
   if (encoding.mode == "environment" && isNamespace(obj)) {
     encoding.mode <- "namespace"
+  }
+
+  # Strip off 'class' from S4 attributes
+  attrib <- attributes(obj)
+  if(isS4(obj)){
+    encoding.mode <- "S4"
+    if (".Data" %in% slotNames(obj)) {
+      attrib[[".Data"]] = obj@.Data
+    }
+    attrib <- attrib[slotNames(obj)]
+    names(attrib) <- slotNames(obj)
   }
 
   # encode recursively

--- a/R/pack.R
+++ b/R/pack.R
@@ -5,6 +5,17 @@ pack <- function(obj, ...) {
   # encode by storage mode
   encoding.mode <- typeof(obj)
 
+  # Strip off 'class' from S4 attributes
+  attrib <- attributes(obj)
+  if(isS4(obj)){
+    encoding.mode <- "S4"
+    if (".Data" %in% slotNames(obj)) {
+      attrib[[".Data"]] = obj@.Data
+    }
+    attrib <- attrib[slotNames(obj)]
+    names(attrib) <- slotNames(obj)
+  }
+
   # null may not have attributes
   if (encoding.mode == "NULL" || identical(obj, as.name('\001NULL\001'))) {
     return(list(type = as.scalar("NULL")))
@@ -18,13 +29,6 @@ pack <- function(obj, ...) {
   # special exception
   if (encoding.mode == "environment" && isNamespace(obj)) {
     encoding.mode <- "namespace"
-  }
-
-  # Strip off 'class' from S4 attributes
-  attrib <- attributes(obj)
-  if(isS4(obj)){
-    attrib <- attrib[slotNames(obj)]
-    names(attrib) <- slotNames(obj)
   }
 
   # encode recursively

--- a/tests/testthat/test-serializeJSON-S4.R
+++ b/tests/testthat/test-serializeJSON-S4.R
@@ -38,3 +38,33 @@ test_that("Class loading errors", {
   expect_error(unserializeJSON('{"type":"S4","attributes":{},"value":{"class":"nonExitingClass","package":".GlobalEnv"}}'), "defined")
   expect_error(expect_warning(unserializeJSON('{"type":"S4","attributes":{},"value":{"class":"nonExitingClass","package":"nopackage"}}')), "nopackage")
 })
+
+
+# S4 extending various SEXP types
+test_that("Serializing S4 extending SEXPTYPE", {
+
+  objects <- list(
+    NULL,
+    readBin(system.file(package="base", "Meta/package.rds"), "raw", 999),
+    c(TRUE, FALSE, NA, FALSE),
+    c(1L, NA, 9999999),
+    c(round(pi, 4), NA, NaN, Inf, -Inf),
+    c("foo", NA, "bar"),
+    complex(real=1:10, imaginary=1001:1010),
+    expression("to be or not to be"),
+    expression(foo),
+    parse(text="rnorm(10);"),
+    list("1", "2", "3"),
+    mtcars,
+    base::matrix(nrow=100, ncol=100)
+  )
+
+  lapply(objects, function(object){
+    setClass("Complexo", contains = c(class(object)))
+    complex1 <- new("Complexo", object)
+    c1 = serializeJSON(complex1)
+    c2 = unserializeJSON(c1)
+    expect_identical(complex1, c2)
+  })
+
+})


### PR DESCRIPTION
Addresses #362. 

Ensures that the ```@.Data``` slot is added to the serialization procedure (when applicable) and address the inconsistency in the special case where ```isS4(class)``` but ```typeof(class)``` does not equal S4. This occurs when S4 extends another class with SEXPTYPE that is not S4. 

We cannot serialize every SEXPTYPE but we can do the majority of them and basically all of the important ones. This is reflected in the testing, which has been added to the serializeJSON-S4 test set. 