### PR TITLE
Memory leak in yajl 2.1.0 with use of yajl_tree_parse function

### DIFF
--- a/src/yajl/yajl_tree.c
+++ b/src/yajl/yajl_tree.c
@@ -150,6 +150,7 @@ static yajl_val context_pop(context_t *ctx)
 
     v = stack->value;
 
+    free (stack->key);
     free (stack);
 
     return (v);
@@ -455,7 +456,14 @@ yajl_val yajl_tree_parse (const char *input,
              snprintf(error_buffer, error_buffer_size, "%s", internal_err_str);
              YA_FREE(&(handle->alloc), internal_err_str);
         }
+        while(ctx.stack != NULL) {
+             yajl_val v = context_pop(&ctx);
+             yajl_tree_free(v);
+        }
         yajl_free (handle);
+        //If the requested memory is not released in time, it will cause memory leakage
+        if(ctx.root)
+             yajl_tree_free(ctx.root);
         return NULL;
     }
 


### PR DESCRIPTION
Fix for CVE-2023-33460

References:
- https://nvd.nist.gov/vuln/detail/CVE-2023-33460
- https://github.com/lloyd/yajl/issues/250
- https://lists.debian.org/debian-lts-announce/2023/07/msg00000.html
- https://lists.debian.org/debian-lts-announce/2023/07/msg00013.html
- https://github.com/jstamp/yajl/blob/master/debian/patches/CVE-2023-33460.patch
- https://bodhi.fedoraproject.org/updates/FEDORA-2023-0b0bb84049