### PR TITLE
Update testthat

### DIFF
--- a/tests/testthat/flatten.R
+++ b/tests/testthat/flatten.R
@@ -3,7 +3,7 @@
 test_that("flattening", {
   x <- list(test = data.frame(foo=1:3))
   x$test$bar <- data.frame(x=5:3, y=7:9)
-  expect_that(x, equals(fromJSON(toJSON(x), flatten = FALSE)));
-  expect_that(names(fromJSON(toJSON(x), flatten = TRUE)$test), equals(c("foo", "bar.x", "bar.y")))
+  expect_equal(x, fromJSON(toJSON(x), flatten = FALSE));
+  expect_equal(names(fromJSON(toJSON(x), flatten = TRUE)$test), c("foo", "bar.x", "bar.y"));
 });
 

--- a/tests/testthat/flatten.R
+++ b/tests/testthat/flatten.R
@@ -1,4 +1,4 @@
-context("flatten")
+
 
 test_that("flattening", {
   x <- list(test = data.frame(foo=1:3))

--- a/tests/testthat/test-fromJSON-NA-values.R
+++ b/tests/testthat/test-fromJSON-NA-values.R
@@ -1,7 +1,7 @@
 
 
 test_that("fromJSON NA values", {
-  
+
   objects <- list(
     numbers = c(1,2, NA, NaN, Inf, -Inf, 3.14),
     logical = c(TRUE, FALSE, NA),
@@ -13,12 +13,12 @@ test_that("fromJSON NA values", {
     boolNA = as.logical(NA),
     df = data.frame(foo=c(1,NA))
   )
-  
+
   #test all but list
   lapply(objects, function(object){
-    expect_that(fromJSON(toJSON(object)), equals(object))   
+    expect_equal(fromJSON(toJSON(object)), object);
   });
-  
+
   #test all in list
-  expect_that(fromJSON(toJSON(objects)), equals(objects))
+  expect_equal(fromJSON(toJSON(objects)), objects);
 });

--- a/tests/testthat/test-fromJSON-NA-values.R
+++ b/tests/testthat/test-fromJSON-NA-values.R
@@ -1,4 +1,4 @@
-context("fromJSON NA values")
+
 
 test_that("fromJSON NA values", {
   

--- a/tests/testthat/test-fromJSON-array.R
+++ b/tests/testthat/test-fromJSON-array.R
@@ -6,48 +6,48 @@ test_that("fromJSON Array, row major", {
   lapply(2:5, function(n){
     object <- array(1:prod(n), dim=1:n)
     newobject <- fromJSON(toJSON(object));
-    expect_that(object, equals(newobject));
+    expect_equal(object, newobject);
   });
-  
+
   # adding some flat dimensions
   lapply(1:5, function(n){
     object <- array(1:prod(n), dim=c(1:n, 1))
     newobject <- fromJSON(toJSON(object));
-    expect_that(object, equals(newobject));
-  });  
+    expect_equal(object, newobject);
+  });
 });
 
 test_that("fromJSON Array, column major", {
-  
+
   # test high dimensional arrays
   lapply(2:5, function(n){
     object <- array(1:prod(n), dim=1:n)
     newobject <- fromJSON(toJSON(object, matrix="columnmajor"), columnmajor=TRUE);
-    expect_that(object, equals(newobject));
+    expect_equal(object, newobject);
   });
-  
+
   # adding some flat dimensions
   lapply(1:5, function(n){
     object <- array(1:prod(n), dim=c(1:n, 1))
     newobject <- fromJSON(toJSON(object, matrix="columnmajor"), columnmajor=TRUE);
-    expect_that(object, equals(newobject));
-  });  
+    expect_equal(object, newobject);
+  });
 });
 
 
 test_that("fromJSON Array, character strings", {
-  
+
   # test high dimensional arrays
   lapply(2:5, function(n){
     object <- array(paste("cell", 1:prod(n)), dim=1:n)
     newobject <- fromJSON(toJSON(object, matrix="columnmajor"), columnmajor=TRUE);
-    expect_that(object, equals(newobject));
+    expect_equal(object, newobject);
   });
-  
+
   # adding some flat dimensions
   lapply(1:5, function(n){
     object <- array(paste("cell", 1:prod(n)), dim=c(1:n, 1))
     newobject <- fromJSON(toJSON(object, matrix="columnmajor"), columnmajor=TRUE);
-    expect_that(object, equals(newobject));
-  });  
+    expect_equal(object, newobject);
+  });
 });

--- a/tests/testthat/test-fromJSON-array.R
+++ b/tests/testthat/test-fromJSON-array.R
@@ -1,4 +1,4 @@
-context("fromJSON Array")
+
 
 test_that("fromJSON Array, row major", {
 

--- a/tests/testthat/test-fromJSON-dataframe.R
+++ b/tests/testthat/test-fromJSON-dataframe.R
@@ -16,13 +16,13 @@ test_that("recover nested data frames", {
 
   #test all but list
   lapply(objects, function(object){
-    expect_that(fromJSON(toJSON(object)), equals(object))
-    expect_that(fromJSON(toJSON(object, na="null")), equals(object))
-    expect_that(names(fromJSON(toJSON(object), flatten = TRUE)), equals(names(unlist(object[1,,drop=FALSE]))))
+    expect_equal(fromJSON(toJSON(object)), object);
+    expect_equal(fromJSON(toJSON(object, na="null")), object);
+    expect_equal(names(fromJSON(toJSON(object), flatten = TRUE)), names(unlist(object[1,,drop=FALSE])));
   });
 
   #test all in list
-  expect_that(fromJSON(toJSON(objects)), equals(objects))
+  expect_equal(fromJSON(toJSON(objects)), objects);
 });
 
 test_that("recover lists in data frames", {
@@ -39,10 +39,10 @@ test_that("recover lists in data frames", {
   z <- list(x=x, y=y);
   zz <- list(x,y);
 
-  expect_that(fromJSON(toJSON(x)), equals(x))
-  expect_that(fromJSON(toJSON(y)), equals(y))
-  expect_that(fromJSON(toJSON(z)), equals(z))
-  expect_that(fromJSON(toJSON(zz)), equals(zz))
+  expect_equal(fromJSON(toJSON(x)), x);
+  expect_equal(fromJSON(toJSON(y)), y);
+  expect_equal(fromJSON(toJSON(z)), z);
+  expect_equal(fromJSON(toJSON(zz)), zz);
 });
 
 #note: nested matrix does not perfectly restore
@@ -53,7 +53,7 @@ test_that("nested matrix in data frame", {
   expect_true(validate(toJSON(x)))
 
   y <- fromJSON(toJSON(x))
-  expect_that(y, is_a("data.frame"))
-  expect_that(names(x), equals(names(y)))
-  expect_that(length(y[[1,"bar"]]), equals(3))
+  expect_s3_class(y, "data.frame");
+  expect_equal(names(x), names(y));
+  expect_equal(length(y[[1,"bar"]]), 3);
 });

--- a/tests/testthat/test-fromJSON-dataframe.R
+++ b/tests/testthat/test-fromJSON-dataframe.R
@@ -1,4 +1,4 @@
-context("fromJSON dataframes")
+
 
 options(stringsAsFactors=FALSE);
 

--- a/tests/testthat/test-fromJSON-datasets.R
+++ b/tests/testthat/test-fromJSON-datasets.R
@@ -1,4 +1,4 @@
-context("fromJSON datasets")
+
 
 # Note about numeric precision
 # In the unit tests we use digits=10. Lowever values will result in problems for some datasets

--- a/tests/testthat/test-fromJSON-datasets.R
+++ b/tests/testthat/test-fromJSON-datasets.R
@@ -4,15 +4,15 @@
 # In the unit tests we use digits=10. Lowever values will result in problems for some datasets
 test_that("fromJSON datasets", {
   objects <- Filter(is.data.frame, lapply(ls("package:datasets"), get));
-  
+
   #data frames are never identical because:
-  # - attributes 
+  # - attributes
   # - factors, times, dates turn into strings
   # - integers turn into numeric
   lapply(objects, function(object){
     newobject <- fromJSON(toJSON(object))
-    expect_that(newobject, is_a("data.frame"));
-    expect_that(names(object), is_identical_to(names(newobject)));
-    expect_that(nrow(object), is_identical_to(nrow(newobject)))
+    expect_s3_class(newobject, "data.frame");
+    expect_identical(names(object), names(newobject));
+    expect_identical(nrow(object), nrow(newobject));
   });
 });

--- a/tests/testthat/test-fromJSON-date.R
+++ b/tests/testthat/test-fromJSON-date.R
@@ -4,16 +4,16 @@ test_that("fromJSON date objects", {
 
   x <- Sys.time() + c(1, 2, NA, 3)
   mydf <- data.frame(x=x)
-  expect_that(fromJSON(toJSON(x, POSIXt="mongo")), is_a("POSIXct"))
-  expect_that(fromJSON(toJSON(x, POSIXt="mongo")), equals(x))
-  #expect_that(fromJSON(toJSON(x, POSIXt="mongo", na="string")), is_a("POSIXct"))
-  expect_that(fromJSON(toJSON(x, POSIXt="mongo", na="null")), is_a("POSIXct"))
+  expect_s3_class(fromJSON(toJSON(x, POSIXt="mongo")), "POSIXct");
+  expect_equal(fromJSON(toJSON(x, POSIXt="mongo")), x);
+  #expect_s3_class(fromJSON(toJSON(x, POSIXt="mongo", na="string")), "POSIXct");
+  expect_s3_class(fromJSON(toJSON(x, POSIXt="mongo", na="null")), "POSIXct");
 
-  expect_that(fromJSON(toJSON(mydf, POSIXt="mongo")), is_a("data.frame"))
-  expect_that(fromJSON(toJSON(mydf, POSIXt="mongo"))$x, is_a("POSIXct"))
-  #expect_that(fromJSON(toJSON(mydf, POSIXt="mongo", na="string"))$x, is_a("POSIXct"))
-  expect_that(fromJSON(toJSON(mydf, POSIXt="mongo", na="null"))$x, is_a("POSIXct"))
-  expect_that(fromJSON(toJSON(mydf, POSIXt="mongo"))$x, equals(x))
+  expect_s3_class(fromJSON(toJSON(mydf, POSIXt="mongo")), "data.frame");
+  expect_s3_class(fromJSON(toJSON(mydf, POSIXt="mongo"))$x, "POSIXct");
+  #expect_s3_class(fromJSON(toJSON(mydf, POSIXt="mongo", na="string"))$x, "POSIXct");
+  expect_s3_class(fromJSON(toJSON(mydf, POSIXt="mongo", na="null"))$x, "POSIXct");
+  expect_equal(fromJSON(toJSON(mydf, POSIXt="mongo"))$x, x);
 
   xct <- as.POSIXct(x)
   xlt <- as.POSIXlt(x)

--- a/tests/testthat/test-fromJSON-date.R
+++ b/tests/testthat/test-fromJSON-date.R
@@ -1,4 +1,4 @@
-context("fromJSON date objects")
+
 
 test_that("fromJSON date objects", {
 

--- a/tests/testthat/test-fromJSON-matrix.R
+++ b/tests/testthat/test-fromJSON-matrix.R
@@ -15,18 +15,18 @@ test_that("fromJSON Matrix", {
 
   lapply(objects, function(object){
     newobject <- fromJSON(toJSON(object));
-    expect_that(newobject, is_a("matrix"));
-    expect_that(object, equals(newobject));
+    expect_true(inherits(newobject, "matrix"));
+    expect_equal(object, newobject);
   });
 
-  expect_that(fromJSON(toJSON(objects)), equals(objects));
+  expect_equal(fromJSON(toJSON(objects)), objects);
 });
 
 test_that("fromJSON Matrix with simplifyMatrix=FALSE", {
-  expect_that(fromJSON(toJSON(matrix(1)), simplifyMatrix=FALSE), equals(list(1)));
-  expect_that(fromJSON(toJSON(matrix(1)), simplifyVector=FALSE), equals(list(list((1)))));
-  expect_that(fromJSON(toJSON(matrix(NA)), simplifyMatrix=FALSE), equals(list(NA)));
-  expect_that(fromJSON(toJSON(matrix(NA)), simplifyVector=FALSE), equals(list(list((NULL)))));
+  expect_equal(fromJSON(toJSON(matrix(1)), simplifyMatrix=FALSE), list(1));
+  expect_equal(fromJSON(toJSON(matrix(1)), simplifyVector=FALSE), list(list((1))));
+  expect_equal(fromJSON(toJSON(matrix(NA)), simplifyMatrix=FALSE), list(NA));
+  expect_equal(fromJSON(toJSON(matrix(NA)), simplifyVector=FALSE), list(list((NULL))));
 });
 
 
@@ -36,12 +36,12 @@ test_that("fromJSON Matrix datasets", {
   lapply(objects, function(object){
     class(object) <- "matrix";
     newobject <- fromJSON(toJSON(object, digits=4))
-    expect_that(newobject, is_a("matrix"));
-    expect_that(dim(newobject), equals(dim(object)));
+    expect_true(inherits(newobject, "matrix"));
+    expect_equal(dim(newobject), dim(object));
     attributes(newobject) <- attributes(object);
 
     # R has changed rounding algo in 4.0 and no longer matches printf
-    #expect_that(newobject, equals(round(object,4)))
+    #expect_equal(newobject, round(object,4));
     expect_equal(newobject, object, tolerance = 1e-4)
   });
 });

--- a/tests/testthat/test-fromJSON-matrix.R
+++ b/tests/testthat/test-fromJSON-matrix.R
@@ -1,4 +1,4 @@
-context("fromJSON Matrix")
+
 
 # Note about numeric precision
 # In the unit tests we use digits=10. Lowever values will result in problems for some datasets

--- a/tests/testthat/test-libjson-escaping.R
+++ b/tests/testthat/test-libjson-escaping.R
@@ -11,11 +11,11 @@ test_that("escaping and parsing of special characters", {
   #generate 1000 random strings
   for(i in 1:200){
     x <- createstring(i);
-    expect_that(x, equals(fromJSON(toJSON(x))));
-    expect_that(x, equals(fromJSON(toJSON(x, pretty=TRUE))));
+    expect_equal(x, fromJSON(toJSON(x)));
+    expect_equal(x, fromJSON(toJSON(x, pretty=TRUE)));
 
     y <- setNames(list(123), x)
-    expect_that(x, equals(fromJSON(toJSON(x, pretty=TRUE))));
+    expect_equal(x, fromJSON(toJSON(x, pretty=TRUE)));
   }
 
 });

--- a/tests/testthat/test-libjson-escaping.R
+++ b/tests/testthat/test-libjson-escaping.R
@@ -1,4 +1,4 @@
-context("libjson Escaping")
+
 
 test_that("escaping and parsing of special characters", {
 

--- a/tests/testthat/test-libjson-large.R
+++ b/tests/testthat/test-libjson-large.R
@@ -1,17 +1,17 @@
 
 
 test_that("escaping and parsing of special characters", {
-  
+
   #create random strings
   mychars <- c('a', 'b', " ", '"', "\\", "\t", "\n", "'", "/", "#", "$");
   createstring <- function(length){
     paste(mychars[ceiling(runif(length, 0, length(mychars)))], collapse="")
-  }  
+  }
 
   #try some very long strings
   for(i in 1:10){
     zz <- list(foo=createstring(1e5))
-    expect_that(zz, equals(fromJSON(toJSON(zz))));
+    expect_equal(zz, fromJSON(toJSON(zz)));
   }
-  
+
 });

--- a/tests/testthat/test-libjson-large.R
+++ b/tests/testthat/test-libjson-large.R
@@ -1,4 +1,4 @@
-context("libjson Large strings")
+
 
 test_that("escaping and parsing of special characters", {
   

--- a/tests/testthat/test-libjson-utf8.R
+++ b/tests/testthat/test-libjson-utf8.R
@@ -23,26 +23,26 @@ test_that("test that non ascii characters are ok", {
     #Encoding(x) <- "UTF-8"
     myjson <- toJSON(x, pretty=TRUE);
     expect_true(validate(myjson));
-    expect_that(fromJSON(myjson), equals(x));
+    expect_equal(fromJSON(myjson), x);
 
     #prettify needs to parse + output
     prettyjson <- prettify(myjson);
     expect_true(validate(prettyjson));
-    expect_that(fromJSON(prettyjson), equals(x));
+    expect_equal(fromJSON(prettyjson), x);
 
     #test encoding is preserved when roundtripping to disk
     tmp <- tempfile()
     write_json(x, tmp)
-    expect_that(read_json(tmp, simplifyVector = TRUE), equals(x));
+    expect_equal(read_json(tmp, simplifyVector = TRUE), x);
     unlink(tmp)
   });
 
   #Test escaped unicode characters
-  expect_that(fromJSON('["Z\\u00FCrich"]'), equals("Z\u00fcrich"));
-  expect_that(fromJSON(prettify('["Z\\u00FCrich"]')), equals("Z\u00fcrich"));
+  expect_equal(fromJSON('["Z\\u00FCrich"]'), "Z\u00fcrich");
+  expect_equal(fromJSON(prettify('["Z\\u00FCrich"]')), "Z\u00fcrich");
 
-  expect_that(length(unique(fromJSON('["Z\\u00FCrich", "Z\u00fcrich"]'))), equals(1L))
-  expect_that(fromJSON('["\\u586B"]'), equals("\u586b"));
-  expect_that(fromJSON(prettify('["\\u586B"]')), equals("\u586B"));
+  expect_equal(length(unique(fromJSON('["Z\\u00FCrich", "Z\u00fcrich"]'))), 1L);
+  expect_equal(fromJSON('["\\u586B"]'), "\u586b");
+  expect_equal(fromJSON(prettify('["\\u586B"]')), "\u586B");
 
 });

--- a/tests/testthat/test-libjson-validator.R
+++ b/tests/testthat/test-libjson-validator.R
@@ -1,4 +1,4 @@
-context("libjson Validator")
+
 
 test_that("test that the validator properly deals with escaped characters", {
 

--- a/tests/testthat/test-network-Github.R
+++ b/tests/testthat/test-network-Github.R
@@ -1,4 +1,4 @@
-context("Github API")
+
 
 test_that("Non Nested", {
   mydata <- fromJSON("https://api.github.com/users/hadley/orgs");

--- a/tests/testthat/test-network-Github.R
+++ b/tests/testthat/test-network-Github.R
@@ -2,50 +2,50 @@
 
 test_that("Non Nested", {
   mydata <- fromJSON("https://api.github.com/users/hadley/orgs");
-  expect_that(mydata, is_a("data.frame"));
+  expect_s3_class(mydata, "data.frame");
 });
 
 test_that("Nested 1 Level", {
   mydata <- fromJSON("https://api.github.com/users/hadley/repos");
-  expect_that(mydata, is_a("data.frame"));
-  expect_that(mydata$owner, is_a("data.frame"));
-  expect_that(nrow(mydata), equals(nrow(mydata$owner)));
+  expect_s3_class(mydata, "data.frame");
+  expect_s3_class(mydata$owner, "data.frame");
+  expect_equal(nrow(mydata), nrow(mydata$owner));
 });
 
 
 test_that("Nested 1 Level", {
   mydata <- fromJSON("https://api.github.com/repos/hadley/ggplot2/issues");
-  expect_that(mydata, is_a("data.frame"));
-  expect_that(mydata$user, is_a("data.frame"));
-  expect_that(mydata$pull_request, is_a("data.frame"));
-  expect_that(nrow(mydata), equals(nrow(mydata$pull_request)));
+  expect_s3_class(mydata, "data.frame");
+  expect_s3_class(mydata$user, "data.frame");
+  expect_s3_class(mydata$pull_request, "data.frame");
+  expect_equal(nrow(mydata), nrow(mydata$pull_request));
 });
 
 test_that("Nested 1 Level within list", {
   mydata <- fromJSON("https://api.github.com/search/repositories?q=tetris+language:assembly&sort=stars&order=desc");
-  expect_that(mydata, is_a("list"));
-  expect_that(mydata$items, is_a("data.frame"));
-  expect_that(mydata$items$owner, is_a("data.frame"));
-  expect_that(nrow(mydata$items), equals(nrow(mydata$items$owner)));
+  expect_type(mydata, "list");
+  expect_s3_class(mydata$items, "data.frame");
+  expect_s3_class(mydata$items$owner, "data.frame");
+  expect_equal(nrow(mydata$items), nrow(mydata$items$owner));
 });
 
 test_that("Nested 2 Level", {
   mydata <- fromJSON("https://api.github.com/repos/hadley/ggplot2/commits");
-  expect_that(mydata, is_a("data.frame"));
-  expect_that(mydata$commit, is_a("data.frame"));
-  expect_that(mydata$commit$author, is_a("data.frame"));
-  expect_that(mydata$commit$author$name, is_a("character"));
-  expect_that(nrow(mydata), equals(nrow(mydata$commit)));
-  expect_that(nrow(mydata), equals(nrow(mydata$commit$author)));
+  expect_s3_class(mydata, "data.frame");
+  expect_s3_class(mydata$commit, "data.frame");
+  expect_s3_class(mydata$commit$author, "data.frame");
+  expect_type(mydata$commit$author$name, "character");
+  expect_equal(nrow(mydata), nrow(mydata$commit));
+  expect_equal(nrow(mydata), nrow(mydata$commit$author));
 });
 
 test_that("Nested inconsistent (payload), one-to-many", {
   mydata <- fromJSON("https://api.github.com/users/hadley/events");
-  expect_that(mydata, is_a("data.frame"));
-  expect_that(mydata$actor, is_a("data.frame"));
-  expect_that(mydata$repo, is_a("data.frame"));
-  expect_that(mydata$type, is_a("character"));
-  expect_that(mydata$payload, is_a("data.frame"));
+  expect_s3_class(mydata, "data.frame");
+  expect_s3_class(mydata$actor, "data.frame");
+  expect_s3_class(mydata$repo, "data.frame");
+  expect_type(mydata$type, "character");
+  expect_s3_class(mydata$payload, "data.frame");
 
   #this is dynamic, depends on data
   if(any(mydata$type == "PushEvent")){
@@ -56,11 +56,11 @@ test_that("Nested inconsistent (payload), one-to-many", {
 test_that("Nested inconsistent (payload), one-to-many", {
   mydata <- fromJSON("https://api.github.com/repos/hadley/ggplot2/events");
   if(any("ForkEvent" %in% mydata$type)){
-    expect_that(mydata$payload$forkee$owner, is_a("data.frame"))
+    expect_s3_class(mydata$payload$forkee$owner, "data.frame");
   }
 
   if(any(mydata$type %in% c("IssuesEvent", "IssueCommentEvent"))){
-    expect_that(mydata$payload$issue, is_a("data.frame"));
-    expect_that(mydata$payload$issue$user, is_a("data.frame"));
+    expect_s3_class(mydata$payload$issue, "data.frame");
+    expect_s3_class(mydata$payload$issue$user, "data.frame");
   }
 });

--- a/tests/testthat/test-serializeJSON-S4.R
+++ b/tests/testthat/test-serializeJSON-S4.R
@@ -1,4 +1,4 @@
-context("Serializing S4 objects")
+
 
 test_that("Simple S4 serialization", {
   setClass("myClass", slots = list(name = "character"))

--- a/tests/testthat/test-serializeJSON-datasets.R
+++ b/tests/testthat/test-serializeJSON-datasets.R
@@ -7,9 +7,9 @@
 test_that("Serializing datasets", {
   library(datasets);
   lapply(as.list(ls("package:datasets")), function(x){
-    mycall <- call("expect_that",
+    mycall <- call("expect_equal",
       call("unserializeJSON", call("serializeJSON", as.name(x), digits=10)),
-      call("equals", as.name(x))
+      as.name(x)
     );
     eval(mycall)
   });

--- a/tests/testthat/test-serializeJSON-datasets.R
+++ b/tests/testthat/test-serializeJSON-datasets.R
@@ -1,4 +1,4 @@
-#test serializeJSON 
+#test serializeJSON
 
 
 
@@ -7,7 +7,7 @@
 test_that("Serializing datasets", {
   library(datasets);
   lapply(as.list(ls("package:datasets")), function(x){
-    mycall <- call("expect_that", 
+    mycall <- call("expect_that",
       call("unserializeJSON", call("serializeJSON", as.name(x), digits=10)),
       call("equals", as.name(x))
     );

--- a/tests/testthat/test-serializeJSON-datasets.R
+++ b/tests/testthat/test-serializeJSON-datasets.R
@@ -1,6 +1,6 @@
 #test serializeJSON 
 
-context("Serializing Datasets")
+
 
 # Note about numeric precision
 # In the unit tests we use digits=10. Lowever values will result in problems for some datasets

--- a/tests/testthat/test-serializeJSON-functions.R
+++ b/tests/testthat/test-serializeJSON-functions.R
@@ -1,6 +1,6 @@
 #test serializeJSON
 
-context("Serializing Functions")
+
 
 # Note about numeric precision
 # In the unit tests we use digits=10. Lowever values will result in problems for some datasets

--- a/tests/testthat/test-serializeJSON-functions.R
+++ b/tests/testthat/test-serializeJSON-functions.R
@@ -19,6 +19,6 @@ test_that("Serializing Functions", {
   lapply(objects, function(object){
     fun <- unserializeJSON(serializeJSON(object))
     environment(fun) <- environment(object)
-    expect_that(fun, equals(object))
+    expect_equal(fun, object);
   })
 })

--- a/tests/testthat/test-serializeJSON-types.R
+++ b/tests/testthat/test-serializeJSON-types.R
@@ -30,10 +30,10 @@ test_that("Serializing Data Objects", {
 
   #test all but list
   lapply(objects, function(object){
-    expect_that(unserializeJSON(serializeJSON(object)), equals(object))
+    expect_equal(unserializeJSON(serializeJSON(object)), object);
   });
 
   #test all in list
-  expect_that(unserializeJSON(serializeJSON(objects)), equals(objects))
+  expect_equal(unserializeJSON(serializeJSON(objects)), objects);
 });
 

--- a/tests/testthat/test-serializeJSON-types.R
+++ b/tests/testthat/test-serializeJSON-types.R
@@ -1,6 +1,6 @@
 #test serializeJSON
 
-context("Serializing Data Types")
+
 
 # Note about numeric precision
 # In the unit tests we use digits=10. Lowever values will result in problems for some datasets

--- a/tests/testthat/test-toJSON-AsIs.R
+++ b/tests/testthat/test-toJSON-AsIs.R
@@ -1,14 +1,14 @@
 
 
 test_that("Encoding AsIs", {
-  expect_that(toJSON(list(1), auto_unbox=TRUE), equals("[1]"));
-  expect_that(toJSON(list(I(1)), auto_unbox=TRUE), equals("[[1]]"));
-  expect_that(toJSON(I(list(1)), auto_unbox=TRUE), equals("[1]"));
+  expect_equal(toJSON(list(1), auto_unbox=TRUE), "[1]");
+  expect_equal(toJSON(list(I(1)), auto_unbox=TRUE), "[[1]]");
+  expect_equal(toJSON(I(list(1)), auto_unbox=TRUE), "[1]");
 
-  expect_that(toJSON(list(x=1)), equals("{\"x\":[1]}"));
-  expect_that(toJSON(list(x=1), auto_unbox=TRUE), equals("{\"x\":1}"));
-  expect_that(toJSON(list(x=I(1)), auto_unbox=TRUE), equals("{\"x\":[1]}"));
+  expect_equal(toJSON(list(x=1)), "{\"x\":[1]}");
+  expect_equal(toJSON(list(x=1), auto_unbox=TRUE), "{\"x\":1}");
+  expect_equal(toJSON(list(x=I(1)), auto_unbox=TRUE), "{\"x\":[1]}");
 
-  expect_that(toJSON(list(x=I(list(1))), auto_unbox=TRUE), equals("{\"x\":[1]}"));
-  expect_that(toJSON(list(x=list(I(1))), auto_unbox=TRUE), equals("{\"x\":[[1]]}"));
+  expect_equal(toJSON(list(x=I(list(1))), auto_unbox=TRUE), "{\"x\":[1]}");
+  expect_equal(toJSON(list(x=list(I(1))), auto_unbox=TRUE), "{\"x\":[[1]]}");
 });

--- a/tests/testthat/test-toJSON-AsIs.R
+++ b/tests/testthat/test-toJSON-AsIs.R
@@ -1,4 +1,4 @@
-context("toJSON AsIs")
+
 
 test_that("Encoding AsIs", {
   expect_that(toJSON(list(1), auto_unbox=TRUE), equals("[1]"));

--- a/tests/testthat/test-toJSON-Date.R
+++ b/tests/testthat/test-toJSON-Date.R
@@ -1,4 +1,4 @@
-context("toJSON Date")
+
 object <- as.Date("1985-06-18");
 
 test_that("Encoding Date Objects", {

--- a/tests/testthat/test-toJSON-Date.R
+++ b/tests/testthat/test-toJSON-Date.R
@@ -2,22 +2,22 @@
 object <- as.Date("1985-06-18");
 
 test_that("Encoding Date Objects", {
-  expect_that(toJSON(object), equals("[\"1985-06-18\"]"));
-  expect_that(toJSON(object, Date="ISO8601"), equals("[\"1985-06-18\"]"));  
-  expect_that(toJSON(object, Date="epoch"), equals("[5647]"));
-  expect_that(toJSON(object, Date="adsfdsfds"), throws_error("should be one of"));  
+  expect_equal(toJSON(object), "[\"1985-06-18\"]");
+  expect_equal(toJSON(object, Date="ISO8601"), "[\"1985-06-18\"]");
+  expect_equal(toJSON(object, Date="epoch"), "[5647]");
+  expect_error(toJSON(object, Date="adsfdsfds"), "should be one of");
 });
 
 test_that("Encoding Date Objects in a list", {
-  expect_that(toJSON(list(foo=object)), equals("{\"foo\":[\"1985-06-18\"]}"));
-  expect_that(toJSON(list(foo=object), Date="ISO8601"), equals("{\"foo\":[\"1985-06-18\"]}"));  
-  expect_that(toJSON(list(foo=object), Date="epoch"), equals("{\"foo\":[5647]}"));
-  expect_that(toJSON(list(foo=object), Date="adsfdsfds"), throws_error("should be one of"));  
+  expect_equal(toJSON(list(foo=object)), "{\"foo\":[\"1985-06-18\"]}");
+  expect_equal(toJSON(list(foo=object), Date="ISO8601"), "{\"foo\":[\"1985-06-18\"]}");
+  expect_equal(toJSON(list(foo=object), Date="epoch"), "{\"foo\":[5647]}");
+  expect_error(toJSON(list(foo=object), Date="adsfdsfds"), "should be one of");
 });
 
 test_that("Encoding Date Objects in a Data frame", {
-  expect_that(toJSON(data.frame(foo=object)), equals("[{\"foo\":\"1985-06-18\"}]"));
-  expect_that(toJSON(data.frame(foo=object), Date="ISO8601"), equals("[{\"foo\":\"1985-06-18\"}]"));  
-  expect_that(toJSON(data.frame(foo=object), Date="epoch"), equals("[{\"foo\":5647}]"));
-  expect_that(toJSON(data.frame(foo=object), Date="adsfdsfds"), throws_error("should be one of"));  
+  expect_equal(toJSON(data.frame(foo=object)), "[{\"foo\":\"1985-06-18\"}]");
+  expect_equal(toJSON(data.frame(foo=object), Date="ISO8601"), "[{\"foo\":\"1985-06-18\"}]");
+  expect_equal(toJSON(data.frame(foo=object), Date="epoch"), "[{\"foo\":5647}]");
+  expect_error(toJSON(data.frame(foo=object), Date="adsfdsfds"), "should be one of");
 });

--- a/tests/testthat/test-toJSON-NA-values.R
+++ b/tests/testthat/test-toJSON-NA-values.R
@@ -1,4 +1,4 @@
-context("toJSON NA values")
+
 
 test_that("Test NA values", {
   options(stringsAsFactors=FALSE)

--- a/tests/testthat/test-toJSON-NA-values.R
+++ b/tests/testthat/test-toJSON-NA-values.R
@@ -7,7 +7,7 @@ test_that("Test NA values", {
   x$mydf$mylist <- list(c(TRUE, NA, FALSE, NA), NA, c("blabla", NA), c(NA,12,13,NA,NA,NA,1001))
 
   expect_true(validate(toJSON(x)))
-  expect_that(fromJSON(toJSON(x)), equals(x))
-  expect_that(fromJSON(toJSON(x, na="null")), equals(x))
+  expect_equal(fromJSON(toJSON(x)), x);
+  expect_equal(fromJSON(toJSON(x, na="null")), x);
 
 });

--- a/tests/testthat/test-toJSON-NULL-values.R
+++ b/tests/testthat/test-toJSON-NULL-values.R
@@ -7,17 +7,17 @@ test_that("Test NULL values", {
   z <- list(a=1, b=character(0))
 
   expect_true(validate(toJSON(x)))
-  expect_that(fromJSON(toJSON(x)), equals(namedlist))
-  expect_that(toJSON(x), equals("{}"))
-  expect_that(toJSON(x, null="list"), equals("{}"))
+  expect_equal(fromJSON(toJSON(x)), namedlist);
+  expect_equal(toJSON(x), "{}");
+  expect_equal(toJSON(x, null="list"), "{}");
 
   expect_true(validate(toJSON(y)))
-  expect_that(toJSON(y, null="list"), equals("{\"a\":{},\"b\":[null]}"))
-  expect_that(toJSON(y, null="null"), equals("{\"a\":null,\"b\":[null]}"))
-  expect_that(fromJSON(toJSON(y, null="null")), equals(y))
-  expect_that(fromJSON(toJSON(y, null="list")), equals(list(a=namedlist, b=NA)))
+  expect_equal(toJSON(y, null="list"), "{\"a\":{},\"b\":[null]}");
+  expect_equal(toJSON(y, null="null"), "{\"a\":null,\"b\":[null]}");
+  expect_equal(fromJSON(toJSON(y, null="null")), y);
+  expect_equal(fromJSON(toJSON(y, null="list")), list(a=namedlist, b=NA));
 
   expect_true(validate(toJSON(z)))
-  expect_that(toJSON(z), equals("{\"a\":[1],\"b\":[]}"))
-  expect_that(fromJSON(toJSON(z)), equals(list(a=1, b=list())))
+  expect_equal(toJSON(z), "{\"a\":[1],\"b\":[]}");
+  expect_equal(fromJSON(toJSON(z)), list(a=1, b=list()));
 });

--- a/tests/testthat/test-toJSON-NULL-values.R
+++ b/tests/testthat/test-toJSON-NULL-values.R
@@ -1,4 +1,4 @@
-context("toJSON NULL values")
+
 
 test_that("Test NULL values", {
   namedlist <- structure(list(), .Names = character(0));

--- a/tests/testthat/test-toJSON-POSIXt.R
+++ b/tests/testthat/test-toJSON-POSIXt.R
@@ -11,16 +11,16 @@ test_that("Encoding POSIXt Objects", {
 
   #string based formats do not depends on the current local timezone
   invisible(lapply(objects, function(object){
-    expect_that(toJSON(object), equals("[\"2013-06-17 22:33:44\"]"));
-    expect_that(toJSON(object, POSIXt="string"), equals("[\"2013-06-17 22:33:44\"]"));
-    expect_that(toJSON(object, POSIXt="ISO8601"), equals("[\"2013-06-17T22:33:44\"]"));
-    expect_that(toJSON(object, POSIXt="sdfsdsdf"), throws_error("one of"));
+    expect_equal(toJSON(object), "[\"2013-06-17 22:33:44\"]");
+    expect_equal(toJSON(object, POSIXt="string"), "[\"2013-06-17 22:33:44\"]");
+    expect_equal(toJSON(object, POSIXt="ISO8601"), "[\"2013-06-17T22:33:44\"]");
+    expect_error(toJSON(object, POSIXt="sdfsdsdf"), "one of");
   }));
 
   #object 1 and 2 will result in a location specific epoch
   invisible(lapply(objects[3:4], function(object){
-    expect_that(toJSON(object, POSIXt="epoch"), equals("[1371474224000]"));
-    expect_that(toJSON(object, POSIXt="mongo"), equals("[{\"$date\":1371474224000}]"));
+    expect_equal(toJSON(object, POSIXt="epoch"), "[1371474224000]");
+    expect_equal(toJSON(object, POSIXt="mongo"), "[{\"$date\":1371474224000}]");
   }));
 
 });
@@ -28,32 +28,32 @@ test_that("Encoding POSIXt Objects", {
 test_that("Encoding POSIXt object in a list", {
   #string based formats do not depends on the current local timezone
   invisible(lapply(objects, function(object){
-    expect_that(toJSON(list(foo=object)), equals("{\"foo\":[\"2013-06-17 22:33:44\"]}"));
-    expect_that(toJSON(list(foo=object), POSIXt="string"), equals("{\"foo\":[\"2013-06-17 22:33:44\"]}"));
-    expect_that(toJSON(list(foo=object), POSIXt="ISO8601"), equals("{\"foo\":[\"2013-06-17T22:33:44\"]}"));
-    expect_that(toJSON(list(foo=object), POSIXt="sdfsdsdf"), throws_error("one of"));
+    expect_equal(toJSON(list(foo=object)), "{\"foo\":[\"2013-06-17 22:33:44\"]}");
+    expect_equal(toJSON(list(foo=object), POSIXt="string"), "{\"foo\":[\"2013-06-17 22:33:44\"]}");
+    expect_equal(toJSON(list(foo=object), POSIXt="ISO8601"), "{\"foo\":[\"2013-06-17T22:33:44\"]}");
+    expect_error(toJSON(list(foo=object), POSIXt="sdfsdsdf"), "one of");
   }));
 
   #list(foo=object) 1 and 2 will result in a location specific epoch
   invisible(lapply(objects[3:4], function(object){
-    expect_that(toJSON(list(foo=object), POSIXt="epoch"), equals("{\"foo\":[1371474224000]}"));
-    expect_that(toJSON(list(foo=object), POSIXt="mongo"), equals("{\"foo\":[{\"$date\":1371474224000}]}"));
+    expect_equal(toJSON(list(foo=object), POSIXt="epoch"), "{\"foo\":[1371474224000]}");
+    expect_equal(toJSON(list(foo=object), POSIXt="mongo"), "{\"foo\":[{\"$date\":1371474224000}]}");
   }));
 });
 
 test_that("Encoding POSIXt object in a list", {
   #string based formats do not depends on the current local timezone
   invisible(lapply(objects, function(object){
-    expect_that(toJSON(data.frame(foo=object)), equals("[{\"foo\":\"2013-06-17 22:33:44\"}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt="string"), equals("[{\"foo\":\"2013-06-17 22:33:44\"}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt="ISO8601"), equals("[{\"foo\":\"2013-06-17T22:33:44\"}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt="sdfsdsdf"), throws_error("one of"));
+    expect_equal(toJSON(data.frame(foo=object)), "[{\"foo\":\"2013-06-17 22:33:44\"}]");
+    expect_equal(toJSON(data.frame(foo=object), POSIXt="string"), "[{\"foo\":\"2013-06-17 22:33:44\"}]");
+    expect_equal(toJSON(data.frame(foo=object), POSIXt="ISO8601"), "[{\"foo\":\"2013-06-17T22:33:44\"}]");
+    expect_error(toJSON(data.frame(foo=object), POSIXt="sdfsdsdf"), "one of");
   }));
 
   #list(foo=object) 1 and 2 will result in a location specific epoch
   invisible(lapply(objects[3:4], function(object){
-    expect_that(toJSON(data.frame(foo=object), POSIXt="epoch"), equals("[{\"foo\":1371474224000}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt="mongo"), equals("[{\"foo\":{\"$date\":1371474224000}}]"));
+    expect_equal(toJSON(data.frame(foo=object), POSIXt="epoch"), "[{\"foo\":1371474224000}]");
+    expect_equal(toJSON(data.frame(foo=object), POSIXt="mongo"), "[{\"foo\":{\"$date\":1371474224000}}]");
   }));
 });
 
@@ -63,11 +63,11 @@ test_that("POSIXt NA values", {
     c(objects[[2]], NA)
   );
   lapply(newobj, function(object){
-    expect_that(toJSON(object), equals("[\"2013-06-17 22:33:44\",null]"));
-    expect_that(toJSON(object, na="string"), equals("[\"2013-06-17 22:33:44\",\"NA\"]"));
-    expect_that(toJSON(data.frame(foo=object)), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{}]"));
-    expect_that(toJSON(data.frame(foo=object), na="null"), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":null}]"));
-    expect_that(toJSON(data.frame(foo=object), na="string"), equals("[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":\"NA\"}]"));
+    expect_equal(toJSON(object), "[\"2013-06-17 22:33:44\",null]");
+    expect_equal(toJSON(object, na="string"), "[\"2013-06-17 22:33:44\",\"NA\"]");
+    expect_equal(toJSON(data.frame(foo=object)), "[{\"foo\":\"2013-06-17 22:33:44\"},{}]");
+    expect_equal(toJSON(data.frame(foo=object), na="null"), "[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":null}]");
+    expect_equal(toJSON(data.frame(foo=object), na="string"), "[{\"foo\":\"2013-06-17 22:33:44\"},{\"foo\":\"NA\"}]");
   });
 
   tzobj <- list(
@@ -75,17 +75,17 @@ test_that("POSIXt NA values", {
     c(objects[[4]], NA)
   );
   lapply(tzobj, function(object) {
-    expect_that(toJSON(object, POSIXt = "mongo"), equals("[{\"$date\":1371474224000},null]"));
-    expect_that(toJSON(object, POSIXt = "mongo", na="string"), equals("[{\"$date\":1371474224000},\"NA\"]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo"), equals("[{\"foo\":{\"$date\":1371474224000}},{}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="null"), equals("[{\"foo\":{\"$date\":1371474224000}},{\"foo\":null}]"));
-    expect_that(toJSON(data.frame(foo=object), POSIXt = "mongo", na="string"), equals("[{\"foo\":{\"$date\":1371474224000}},{\"foo\":\"NA\"}]"));
+    expect_equal(toJSON(object, POSIXt = "mongo"), "[{\"$date\":1371474224000},null]");
+    expect_equal(toJSON(object, POSIXt = "mongo", na="string"), "[{\"$date\":1371474224000},\"NA\"]");
+    expect_equal(toJSON(data.frame(foo=object), POSIXt = "mongo"), "[{\"foo\":{\"$date\":1371474224000}},{}]");
+    expect_equal(toJSON(data.frame(foo=object), POSIXt = "mongo", na="null"), "[{\"foo\":{\"$date\":1371474224000}},{\"foo\":null}]");
+    expect_equal(toJSON(data.frame(foo=object), POSIXt = "mongo", na="string"), "[{\"foo\":{\"$date\":1371474224000}},{\"foo\":\"NA\"}]");
   })
 });
 
 test_that("Negative dates", {
   x <- objects[[2]]
   y <- x - c(1e9, 2e9, 3e9)
-  expect_that(fromJSON(toJSON(y, POSIXt = "mongo")), equals(y))
+  expect_equal(fromJSON(toJSON(y, POSIXt = "mongo")), y);
 })
 

--- a/tests/testthat/test-toJSON-POSIXt.R
+++ b/tests/testthat/test-toJSON-POSIXt.R
@@ -1,4 +1,4 @@
-context("toJSON POSIXt")
+
 
 objects <- list(
   as.POSIXlt("2013-06-17 22:33:44"),

--- a/tests/testthat/test-toJSON-complex.R
+++ b/tests/testthat/test-toJSON-complex.R
@@ -1,4 +1,4 @@
-context("toJSON Complex")
+
 
 test_that("Encoding Complex", {
   expect_that(toJSON(complex(real=2, imaginary=2)), equals("[\"2+2i\"]"));

--- a/tests/testthat/test-toJSON-complex.R
+++ b/tests/testthat/test-toJSON-complex.R
@@ -1,24 +1,24 @@
 
 
 test_that("Encoding Complex", {
-  expect_that(toJSON(complex(real=2, imaginary=2)), equals("[\"2+2i\"]"));
-  expect_that(toJSON(complex(real=NA, imaginary=2)), equals("[\"NA\"]"));  
-  expect_that(toJSON(complex(real=1, imaginary=NA)), equals("[\"NA\"]"));   
-  expect_that(toJSON(complex(real=NA, imaginary=2), na="null"), equals("[null]")); 
+  expect_equal(toJSON(complex(real=2, imaginary=2)), "[\"2+2i\"]");
+  expect_equal(toJSON(complex(real=NA, imaginary=2)), "[\"NA\"]");
+  expect_equal(toJSON(complex(real=1, imaginary=NA)), "[\"NA\"]");
+  expect_equal(toJSON(complex(real=NA, imaginary=2), na="null"), "[null]");
 });
 
 test_that("Encoding Complex in Data Frame", {
-  expect_that(toJSON(data.frame(foo=complex(real=1, imaginary=2))), equals("[{\"foo\":\"1+2i\"}]"));
-  expect_that(toJSON(data.frame(foo=complex(real=NA, imaginary=2))), equals("[{}]"));
-  expect_that(toJSON(data.frame(foo=complex(real=NA, imaginary=2)), na="string"), equals("[{\"foo\":\"NA\"}]"));
-  expect_that(toJSON(data.frame(foo=complex(real=NA, imaginary=2)), na="null"), equals("[{\"foo\":null}]"));
+  expect_equal(toJSON(data.frame(foo=complex(real=1, imaginary=2))), "[{\"foo\":\"1+2i\"}]");
+  expect_equal(toJSON(data.frame(foo=complex(real=NA, imaginary=2))), "[{}]");
+  expect_equal(toJSON(data.frame(foo=complex(real=NA, imaginary=2)), na="string"), "[{\"foo\":\"NA\"}]");
+  expect_equal(toJSON(data.frame(foo=complex(real=NA, imaginary=2)), na="null"), "[{\"foo\":null}]");
 });
 
 test_that("Encoding Complex as list", {
   x <- complex(real=c(1,2,NA), imaginary=3:1);
-  expect_that(toJSON(x), equals("[\"1+3i\",\"2+2i\",\"NA\"]"));
-  expect_that(toJSON(x, complex="list"), equals("{\"real\":[1,2,\"NA\"],\"imaginary\":[3,2,1]}"));
-  expect_that(toJSON(data.frame(foo=x), complex="list"), equals("[{\"foo\":{\"real\":1,\"imaginary\":3}},{\"foo\":{\"real\":2,\"imaginary\":2}},{\"foo\":{\"imaginary\":1}}]"));
-  expect_that(toJSON(data.frame(foo=x), complex="list", na="string"), equals("[{\"foo\":{\"real\":1,\"imaginary\":3}},{\"foo\":{\"real\":2,\"imaginary\":2}},{\"foo\":{\"real\":\"NA\",\"imaginary\":1}}]"));
-  expect_that(toJSON(data.frame(foo=x), complex="list", dataframe="columns"), equals("{\"foo\":{\"real\":[1,2,\"NA\"],\"imaginary\":[3,2,1]}}"))
+  expect_equal(toJSON(x), "[\"1+3i\",\"2+2i\",\"NA\"]");
+  expect_equal(toJSON(x, complex="list"), "{\"real\":[1,2,\"NA\"],\"imaginary\":[3,2,1]}");
+  expect_equal(toJSON(data.frame(foo=x), complex="list"), "[{\"foo\":{\"real\":1,\"imaginary\":3}},{\"foo\":{\"real\":2,\"imaginary\":2}},{\"foo\":{\"imaginary\":1}}]");
+  expect_equal(toJSON(data.frame(foo=x), complex="list", na="string"), "[{\"foo\":{\"real\":1,\"imaginary\":3}},{\"foo\":{\"real\":2,\"imaginary\":2}},{\"foo\":{\"real\":\"NA\",\"imaginary\":1}}]");
+  expect_equal(toJSON(data.frame(foo=x), complex="list", dataframe="columns"), "{\"foo\":{\"real\":[1,2,\"NA\"],\"imaginary\":[3,2,1]}}");
 });

--- a/tests/testthat/test-toJSON-dataframe.R
+++ b/tests/testthat/test-toJSON-dataframe.R
@@ -1,4 +1,4 @@
-context("toJSON Data Frame")
+
 
 test_that("data frame edge cases", {
  #unname named list

--- a/tests/testthat/test-toJSON-dataframe.R
+++ b/tests/testthat/test-toJSON-dataframe.R
@@ -5,11 +5,11 @@ test_that("data frame edge cases", {
   test <- data.frame(foo=1:2)
   test$bar <- list(x=123, y=123)
   test$baz <- data.frame(z=456:457)
-  expect_that(toJSON(test), equals('[{"foo":1,"bar":[123],"baz":{"z":456}},{"foo":2,"bar":[123],"baz":{"z":457}}]'))
+  expect_equal(toJSON(test), '[{"foo":1,"bar":[123],"baz":{"z":456}},{"foo":2,"bar":[123],"baz":{"z":457}}]');
 });
 
 test_that("Nested structures", {
-  
+
   mydata <- data.frame(row.names=1:2)
   mydata$d <- list(
     data.frame(a1=1:2, a2=3:4, a3=5:6, a4=7:8),
@@ -19,6 +19,6 @@ test_that("Nested structures", {
     matrix(1:6, nrow=2, ncol=3),
     matrix(6:1, nrow=2, ncol=3)
   )
-  
-  expect_that(fromJSON(toJSON(mydata)), equals(mydata));
+
+  expect_equal(fromJSON(toJSON(mydata)), mydata);
 });

--- a/tests/testthat/test-toJSON-factor.R
+++ b/tests/testthat/test-toJSON-factor.R
@@ -1,7 +1,7 @@
 
 
 test_that("Encoding Factor Objects", {
-  expect_that(fromJSON(toJSON(iris$Species)), is_identical_to(as.character(iris$Species)));
-  expect_that(fromJSON(toJSON(iris$Species[1])), is_identical_to(as.character(iris$Species[1])));
-  expect_that(fromJSON(toJSON(iris$Species, factor="integer")), equals(structure(unclass(iris$Species), levels=NULL)));
+  expect_identical(fromJSON(toJSON(iris$Species)), as.character(iris$Species));
+  expect_identical(fromJSON(toJSON(iris$Species[1])), as.character(iris$Species[1]));
+  expect_equal(fromJSON(toJSON(iris$Species, factor="integer")), structure(unclass(iris$Species), levels=NULL));
 });

--- a/tests/testthat/test-toJSON-factor.R
+++ b/tests/testthat/test-toJSON-factor.R
@@ -1,4 +1,4 @@
-context("toJSON Factor")
+
 
 test_that("Encoding Factor Objects", {
   expect_that(fromJSON(toJSON(iris$Species)), is_identical_to(as.character(iris$Species)));

--- a/tests/testthat/test-toJSON-logical.R
+++ b/tests/testthat/test-toJSON-logical.R
@@ -1,21 +1,21 @@
 
 
 test_that("Encoding Logical", {
-  expect_that(toJSON(TRUE), equals("[true]"));
-  expect_that(toJSON(FALSE), equals("[false]"));
-  expect_that(toJSON(as.logical(NA)), equals("[null]"))
-  expect_that(toJSON(as.logical(NA), na="string"), equals("[\"NA\"]"))
-  expect_that(toJSON(c(TRUE, NA, FALSE)), equals("[true,null,false]"));
-  expect_that(toJSON(c(TRUE, NA, FALSE), na="string"), equals("[true,\"NA\",false]"));
-  expect_that(toJSON(logical()), equals("[]"));
+  expect_equal(toJSON(TRUE), "[true]");
+  expect_equal(toJSON(FALSE), "[false]");
+  expect_equal(toJSON(as.logical(NA)), "[null]");
+  expect_equal(toJSON(as.logical(NA), na="string"), "[\"NA\"]");
+  expect_equal(toJSON(c(TRUE, NA, FALSE)), "[true,null,false]");
+  expect_equal(toJSON(c(TRUE, NA, FALSE), na="string"), "[true,\"NA\",false]");
+  expect_equal(toJSON(logical()), "[]");
 });
 
 test_that("Encoding Logical in Data Frame", {
-  expect_that(toJSON(data.frame(foo=TRUE)), equals("[{\"foo\":true}]"));
-  expect_that(toJSON(data.frame(foo=FALSE)), equals("[{\"foo\":false}]"));
-  expect_that(toJSON(data.frame(foo=as.logical(NA))), equals("[{}]"));
-  expect_that(toJSON(data.frame(foo=as.logical(NA)), na="null"), equals("[{\"foo\":null}]"));
-  expect_that(toJSON(data.frame(foo=as.logical(NA)), na="string"), equals("[{\"foo\":\"NA\"}]"));
-  expect_that(toJSON(data.frame(foo=c(TRUE, NA, FALSE))), equals("[{\"foo\":true},{},{\"foo\":false}]"));
-  expect_that(toJSON(data.frame(foo=logical())), equals("[]"));
+  expect_equal(toJSON(data.frame(foo=TRUE)), "[{\"foo\":true}]");
+  expect_equal(toJSON(data.frame(foo=FALSE)), "[{\"foo\":false}]");
+  expect_equal(toJSON(data.frame(foo=as.logical(NA))), "[{}]");
+  expect_equal(toJSON(data.frame(foo=as.logical(NA)), na="null"), "[{\"foo\":null}]");
+  expect_equal(toJSON(data.frame(foo=as.logical(NA)), na="string"), "[{\"foo\":\"NA\"}]");
+  expect_equal(toJSON(data.frame(foo=c(TRUE, NA, FALSE))), "[{\"foo\":true},{},{\"foo\":false}]");
+  expect_equal(toJSON(data.frame(foo=logical())), "[]");
 });

--- a/tests/testthat/test-toJSON-logical.R
+++ b/tests/testthat/test-toJSON-logical.R
@@ -1,4 +1,4 @@
-context("toJSON Logical")
+
 
 test_that("Encoding Logical", {
   expect_that(toJSON(TRUE), equals("[true]"));

--- a/tests/testthat/test-toJSON-matrix.R
+++ b/tests/testthat/test-toJSON-matrix.R
@@ -1,4 +1,4 @@
-context("toJSON Matrix")
+
 
 test_that("Encoding a Matrix", {
   expect_that(toJSON(matrix(1)), equals("[[1]]"));

--- a/tests/testthat/test-toJSON-matrix.R
+++ b/tests/testthat/test-toJSON-matrix.R
@@ -1,9 +1,9 @@
 
 
 test_that("Encoding a Matrix", {
-  expect_that(toJSON(matrix(1)), equals("[[1]]"));
-  expect_that(toJSON(matrix(pi), digits=5), equals("[[3.14159]]"));
-  expect_that(toJSON(matrix(1:2)), equals("[[1],[2]]"));  
-  expect_that(toJSON(matrix(1:2, nrow=1)), equals("[[1,2]]")); 
-  expect_that(toJSON(matrix(state.x77[1,1, drop=FALSE])), equals("[[3615]]"));
+  expect_equal(toJSON(matrix(1)), "[[1]]");
+  expect_equal(toJSON(matrix(pi), digits=5), "[[3.14159]]");
+  expect_equal(toJSON(matrix(1:2)), "[[1],[2]]");
+  expect_equal(toJSON(matrix(1:2, nrow=1)), "[[1,2]]");
+  expect_equal(toJSON(matrix(state.x77[1,1, drop=FALSE])), "[[3615]]");
 });

--- a/tests/testthat/test-toJSON-numeric.R
+++ b/tests/testthat/test-toJSON-numeric.R
@@ -1,29 +1,29 @@
 
 
 test_that("Encoding Numbers", {
-  expect_that(toJSON(35), equals("[35]"));
-  expect_that(toJSON(35L), equals("[35]"));
-  expect_that(toJSON(c(35, pi), digits=5), equals("[35,3.14159]"));
-  expect_that(toJSON(pi, digits=0), equals("[3]"));
-  expect_that(toJSON(pi, digits=2), equals("[3.14]"));
-  expect_that(toJSON(pi, digits=10), equals("[3.1415926536]"));
-  expect_that(toJSON(c(pi, NA), na="string", digits=5), equals("[3.14159,\"NA\"]"));
-  expect_that(toJSON(c(pi, NA), na="null", digits=5), equals("[3.14159,null]"));
-  expect_that(toJSON(c(pi, NA), na="null", digits=5), equals("[3.14159,null]"));
-  expect_that(toJSON(c(1478002353.51369, -521997646.486311) * 1000, digits = 0), equals("[1478002353514,-521997646486]"));
-  expect_that(toJSON(list(a=c(0.1)), digits = NA), equals('{"a":[0.1]}'));
+  expect_equal(toJSON(35), "[35]");
+  expect_equal(toJSON(35L), "[35]");
+  expect_equal(toJSON(c(35, pi), digits=5), "[35,3.14159]");
+  expect_equal(toJSON(pi, digits=0), "[3]");
+  expect_equal(toJSON(pi, digits=2), "[3.14]");
+  expect_equal(toJSON(pi, digits=10), "[3.1415926536]");
+  expect_equal(toJSON(c(pi, NA), na="string", digits=5), "[3.14159,\"NA\"]");
+  expect_equal(toJSON(c(pi, NA), na="null", digits=5), "[3.14159,null]");
+  expect_equal(toJSON(c(pi, NA), na="null", digits=5), "[3.14159,null]");
+  expect_equal(toJSON(c(1478002353.51369, -521997646.486311) * 1000, digits = 0), "[1478002353514,-521997646486]");
+  expect_equal(toJSON(list(a=c(0.1)), digits = NA), '{"a":[0.1]}');
 });
 
 test_that("Encoding Numbers in Data Frame", {
-  expect_that(toJSON(data.frame(foo=35)), equals("[{\"foo\":35}]"));
-  expect_that(toJSON(data.frame(foo=35L)), equals("[{\"foo\":35}]"));
-  expect_that(toJSON(data.frame(foo=c(35, pi)), digits=5), equals("[{\"foo\":35},{\"foo\":3.14159}]"));
-  expect_that(toJSON(data.frame(foo=pi), digits=0), equals("[{\"foo\":3}]"));
-  expect_that(toJSON(data.frame(foo=pi), digits=2), equals("[{\"foo\":3.14}]"));
-  expect_that(toJSON(data.frame(foo=pi), digits=10), equals("[{\"foo\":3.1415926536}]"));
-  expect_that(toJSON(data.frame(foo=c(pi, NA)), digits=5), equals("[{\"foo\":3.14159},{}]"));
-  expect_that(toJSON(data.frame(foo=c(pi, NA)), na="string", digits=5), equals("[{\"foo\":3.14159},{\"foo\":\"NA\"}]"));
-  expect_that(toJSON(data.frame(foo=c(pi, NA)), na="null", digits=5), equals("[{\"foo\":3.14159},{\"foo\":null}]"));
+  expect_equal(toJSON(data.frame(foo=35)), "[{\"foo\":35}]");
+  expect_equal(toJSON(data.frame(foo=35L)), "[{\"foo\":35}]");
+  expect_equal(toJSON(data.frame(foo=c(35, pi)), digits=5), "[{\"foo\":35},{\"foo\":3.14159}]");
+  expect_equal(toJSON(data.frame(foo=pi), digits=0), "[{\"foo\":3}]");
+  expect_equal(toJSON(data.frame(foo=pi), digits=2), "[{\"foo\":3.14}]");
+  expect_equal(toJSON(data.frame(foo=pi), digits=10), "[{\"foo\":3.1415926536}]");
+  expect_equal(toJSON(data.frame(foo=c(pi, NA)), digits=5), "[{\"foo\":3.14159},{}]");
+  expect_equal(toJSON(data.frame(foo=c(pi, NA)), na="string", digits=5), "[{\"foo\":3.14159},{\"foo\":\"NA\"}]");
+  expect_equal(toJSON(data.frame(foo=c(pi, NA)), na="null", digits=5), "[{\"foo\":3.14159},{\"foo\":null}]");
 });
 
 test_that("Force decimal works", {

--- a/tests/testthat/test-toJSON-numeric.R
+++ b/tests/testthat/test-toJSON-numeric.R
@@ -1,4 +1,4 @@
-context("toJSON Numeric")
+
 
 test_that("Encoding Numbers", {
   expect_that(toJSON(35), equals("[35]"));

--- a/tests/testthat/test-toJSON-raw.R
+++ b/tests/testthat/test-toJSON-raw.R
@@ -1,4 +1,4 @@
-context("toJSON raw")
+
 
 test_that("Encoding raw vector", {
   x <- list(myraw = charToRaw("bla"))

--- a/tests/testthat/test-toJSON-raw.R
+++ b/tests/testthat/test-toJSON-raw.R
@@ -6,8 +6,8 @@ test_that("Encoding raw vector", {
   x$mydf$bar <- as.character.hexmode(charToRaw("bla"))
 
   y <- fromJSON(toJSON(x))
-  expect_that(x$mydf$bar, is_identical_to(y$mydf$bar))
-  expect_that(y$myraw, is_identical_to("Ymxh"))
+  expect_identical(x$mydf$bar, y$mydf$bar);
+  expect_identical(y$myraw, "Ymxh");
 
   # Serialize raw as int
   y <- fromJSON(toJSON(x, raw = 'int'))

--- a/tests/testthat/test-toJSON-zerovec.R
+++ b/tests/testthat/test-toJSON-zerovec.R
@@ -1,23 +1,23 @@
 
 
 test_that("Encoding Factor Objects", {
-  expect_that(toJSON(character()), is_identical_to("[]"))
-  expect_that(toJSON(logical()), is_identical_to("[]"))
-  expect_that(toJSON(complex()), is_identical_to("[]"))
-  expect_that(toJSON(complex(), complex="list"), is_identical_to("{\"real\":[],\"imaginary\":[]}"))
-  expect_that(toJSON(double()), is_identical_to("[]"))
-  expect_that(toJSON(integer()), is_identical_to("[]"))
-  expect_that(toJSON(list()), is_identical_to("[]"))
-  expect_that(toJSON(factor()), is_identical_to("[]"))
-  expect_that(toJSON(factor(levels=c("foo", "bar"))), is_identical_to("[]"))
-  expect_that(toJSON(matrix(nrow=0, ncol=0)), is_identical_to("[]"))
-  expect_that(toJSON(as.matrix(numeric())), is_identical_to("[]"))
-  expect_that(toJSON(data.frame()), is_identical_to("[]"))
-  expect_that(toJSON(data.frame(foo=vector())), is_identical_to("[]"))  
-  expect_that(toJSON(data.frame(foo=vector(), bar=logical())), is_identical_to("[]"))
-  expect_that(toJSON(Sys.time()[0], POSIXt="string"), is_identical_to("[]"))
-  expect_that(toJSON(Sys.time()[0], POSIXt="epoch"), is_identical_to("[]")) 
-  expect_that(toJSON(Sys.time()[0], POSIXt="mongo"), is_identical_to("[]")) 
-  expect_that(toJSON(Sys.time()[0], POSIXt="ISO8601"), is_identical_to("[]")) 
-  expect_that(toJSON(as.Date(Sys.time())[0], POSIXt="ISO8601"), is_identical_to("[]"))
+  expect_identical(toJSON(character()), "[]");
+  expect_identical(toJSON(logical()), "[]");
+  expect_identical(toJSON(complex()), "[]");
+  expect_identical(toJSON(complex(), complex="list"), "{\"real\":[],\"imaginary\":[]}");
+  expect_identical(toJSON(double()), "[]");
+  expect_identical(toJSON(integer()), "[]");
+  expect_identical(toJSON(list()), "[]");
+  expect_identical(toJSON(factor()), "[]");
+  expect_identical(toJSON(factor(levels=c("foo", "bar"))), "[]");
+  expect_identical(toJSON(matrix(nrow=0, ncol=0)), "[]");
+  expect_identical(toJSON(as.matrix(numeric())), "[]");
+  expect_identical(toJSON(data.frame()), "[]");
+  expect_identical(toJSON(data.frame(foo=vector())), "[]");
+  expect_identical(toJSON(data.frame(foo=vector(), bar=logical())), "[]");
+  expect_identical(toJSON(Sys.time()[0], POSIXt="string"), "[]");
+  expect_identical(toJSON(Sys.time()[0], POSIXt="epoch"), "[]");
+  expect_identical(toJSON(Sys.time()[0], POSIXt="mongo"), "[]");
+  expect_identical(toJSON(Sys.time()[0], POSIXt="ISO8601"), "[]");
+  expect_identical(toJSON(as.Date(Sys.time())[0], POSIXt="ISO8601"), "[]");
 });

--- a/tests/testthat/test-toJSON-zerovec.R
+++ b/tests/testthat/test-toJSON-zerovec.R
@@ -1,4 +1,4 @@
-context("toJSON zerovec")
+
 
 test_that("Encoding Factor Objects", {
   expect_that(toJSON(character()), is_identical_to("[]"))


### PR DESCRIPTION
In relation to Issue #422, this PR updates the use of testthat to current practices 

* Remove `context()` calls
* Replace `expect_that()` with explicit `expect_*()` calls e.g. `expect_equal()`