### PR TITLE
#include <math.h> for ceil, fmin, fmax, fabs, log10

### DIFF
--- a/src/num_to_char.c
+++ b/src/num_to_char.c
@@ -1,5 +1,6 @@
 #include <Rdefines.h>
 #include <Rinternals.h>
+#include <math.h>
 #include <stdlib.h>
 #include "modp_numtoa.h"
 


### PR DESCRIPTION
We could also add these indirectly-included headers:

 - `<stdio.h>` for `snprintf`
 - `<string.h>` for `strspn`, `strlen`, `strcat`

These three (`<math.h>`, `<stdio.h>`, `<string.h>`) could replace `<stdlib.h>`.

We could also add specific headers for R:

 - `<R_ext/Arith.h>` for `NA_LOGICAL`, `NA_INTEGER`, `ISNA`, `ISNAN`, `R_FINITE`, `R_PosInf`, `R_NegInf`
 - `<R_ext/Error.h>` for `error`

---

Feel free to request any of these changes, or to just close if transitive inclusion via `<stdlib.h>` is fine with you.