### PR TITLE
Add `encoding_modes` option to `unserialiseJSON()`

### DIFF
--- a/R/pack.R
+++ b/R/pack.R
@@ -71,7 +71,7 @@ unpack <- function(obj, encoding_modes) {
       sprintf(
         "Encoding mode '%s' is not one of %s",
         encoding.mode,
-        paste("'", encoding_modes, "'", collapse = ", ")
+        paste0("'", encoding_modes, "'", collapse = ", ")
       )
     )
   }

--- a/R/serializeJSON.R
+++ b/R/serializeJSON.R
@@ -13,6 +13,8 @@
 #' @param x an \R{} object to be serialized
 #' @param digits max number of digits (after the dot) to print for numeric values
 #' @param pretty add indentation/whitespace to JSON output. See [prettify()]
+#' @param encoding_modes An optional list of allowed encoding modes when
+#'   deserializing JSON into R objects.
 #' @note JSON is a text based format which leads to loss of precision when printing numbers.
 #' @examples jsoncars <- serializeJSON(mtcars)
 #' mtcars2 <- unserializeJSON(jsoncars)
@@ -43,6 +45,6 @@ serializeJSON <- function(x, digits = 8, pretty = FALSE) {
 
 #' @param txt a JSON string which was created using `serializeJSON`
 #' @rdname serializeJSON
-unserializeJSON <- function(txt) {
-  unpack(parseJSON(txt))
+unserializeJSON <- function(txt, encoding_modes = NULL) {
+  unpack(parseJSON(txt), encoding_modes = encoding_modes)
 }

--- a/man/serializeJSON.Rd
+++ b/man/serializeJSON.Rd
@@ -7,7 +7,7 @@
 \usage{
 serializeJSON(x, digits = 8, pretty = FALSE)
 
-unserializeJSON(txt)
+unserializeJSON(txt, encoding_modes = NULL)
 }
 \arguments{
 \item{x}{an \R{} object to be serialized}
@@ -17,6 +17,9 @@ unserializeJSON(txt)
 \item{pretty}{add indentation/whitespace to JSON output. See \code{\link[=prettify]{prettify()}}}
 
 \item{txt}{a JSON string which was created using \code{serializeJSON}}
+
+\item{encoding_modes}{An optional list of allowed encoding modes when
+deserializing JSON into R objects.}
 }
 \description{
 The \code{\link[=serializeJSON]{serializeJSON()}} and \code{\link[=unserializeJSON]{unserializeJSON()}} functions convert between

--- a/tests/testthat/test-serializeJSON-types.R
+++ b/tests/testthat/test-serializeJSON-types.R
@@ -35,5 +35,24 @@ test_that("Serializing Data Objects", {
 
   #test all in list
   expect_equal(unserializeJSON(serializeJSON(objects)), objects);
-});
+})
 
+test_that("Serializing Data Objects with encoding_modes", {
+  objects <- list(character(), logical(), new.env(parent=emptyenv()))
+
+  expect_equal(
+    unserializeJSON(
+      serializeJSON(objects),
+      encoding_modes = c("list", "character", "logical", "environment")
+    ),
+    objects
+  )
+
+  expect_error(
+    unserializeJSON(
+      serializeJSON(objects),
+      encoding_modes = c("list", "character", "logical")
+    ),
+    "Encoding mode 'environment' is not one of 'list', 'character', 'logical'"
+  )
+})


### PR DESCRIPTION
This PR adds an option to `unserializeJSON()` to limit the types of things that the serialized JSON is allowed to contain. Happy to take a different approach (or perhaps there is another function I should be using!)