### PR TITLE
Free memory allocated by base64_encode()

### DIFF
--- a/src/r-base64.c
+++ b/src/r-base64.c
@@ -13,6 +13,7 @@ SEXP R_base64_encode(SEXP buf){
     Rf_error("Error in base64 encode");
   SEXP res = PROTECT(allocVector(STRSXP, 1));
   SET_STRING_ELT(res, 0, mkCharLen((char*) out, outlen));
+  free(out);
   UNPROTECT(1);
   return res;
 }


### PR DESCRIPTION
This showed up in nanoarrow's CI: https://github.com/apache/arrow-nanoarrow/actions/runs/9823176470/job/27120757486#step:4:3425

For both encoding and decoding it looks like the pointers will leak if the following R allocation fails (probably unlikely with the size of raw vectors usually encoded/decoded, though).

