### PR TITLE
No need to special case stdbool.h on Windows

### DIFF
--- a/src/modp_stdint.h
+++ b/src/modp_stdint.h
@@ -15,29 +15,7 @@
 
 #include <string.h>
 
-#ifndef _WIN32
-#  include <stdint.h>
-#  include <stdbool.h>
-#else
-/* win64 is llp64 so these are the same for 32/64bit
-   so no check for _WIN64 is required.
- */
-  typedef unsigned char uint8_t;
-  typedef signed char int8_t;
-  typedef unsigned short uint16_t;
-  typedef signed short int16_t;
-  typedef unsigned int uint32_t;
-  typedef signed int int32_t;
-  typedef unsigned __int64 uint64_t;
-  typedef signed __int64 int64_t;
+#include <stdint.h>
+#include <stdbool.h>
 
-/* windows doesn't do C99 and stdbool */
-
-#ifndef __cplusplus
-typedef unsigned char bool;
-#define true 1
-#define false 0
-#endif
-
-#endif /* _WIN32 */
 #endif /* MODP_STDINT_H_ */


### PR DESCRIPTION
Any more. Fixes compilation on R-devel Windows.

I tested this for every minor R version since R 3.5.3.