### PR TITLE
Add `na="null_specials"` to differentiate Inf/NaN from NA

### DIFF
--- a/R/asJSON.character.R
+++ b/R/asJSON.character.R
@@ -1,4 +1,4 @@
-setMethod("asJSON", "character", function(x, collapse = TRUE, na = c("null", "string", "NA"), auto_unbox = FALSE, keep_vec_names = FALSE, indent = NA_integer_, ...) {
+setMethod("asJSON", "character", function(x, collapse = TRUE, na = c("null", "string", "NA", "null_specials"), auto_unbox = FALSE, keep_vec_names = FALSE, indent = NA_integer_, ...) {
   # Needed for multi-byte Windows locales
   # See: https://github.com/jeroen/jsonlite/issues/329
   x <- enc2utf8(x)
@@ -21,7 +21,7 @@ setMethod("asJSON", "character", function(x, collapse = TRUE, na = c("null", "st
   # validate NA
   if (any(missings <- which(is.na(x)))) {
     na <- match.arg(na)
-    if (na %in% c("null")) {
+    if (na %in% c("null", "null_specials")) {
       tmp[missings] <- "null"
     } else if (na %in% "string") {
       tmp[missings] <- "\"NA\""

--- a/R/asJSON.complex.R
+++ b/R/asJSON.complex.R
@@ -1,4 +1,4 @@
-setMethod("asJSON", "complex", function(x, digits = 5, collapse = TRUE, complex = c("string", "list"), na = c("string", "null", "NA"), oldna = NULL, ...) {
+setMethod("asJSON", "complex", function(x, digits = 5, collapse = TRUE, complex = c("string", "list"), na = c("string", "null", "NA", "null_specials"), oldna = NULL, ...) {
   # validate
   na <- match.arg(na)
   complex <- match.arg(complex)
@@ -8,7 +8,7 @@ setMethod("asJSON", "complex", function(x, digits = 5, collapse = TRUE, complex 
     #default NA is "NA"
     mystring <- prettyNum(x = x, digits = digits)
     if (any(missings <- which(!is.finite(x)))) {
-      if (na %in% c("null", "NA")) {
+      if (na %in% c("null", "NA", "null_specials")) {
         mystring[missings] <- NA_character_
       }
     }

--- a/R/asJSON.data.frame.R
+++ b/R/asJSON.data.frame.R
@@ -1,4 +1,4 @@
-setMethod("asJSON", "data.frame", function(x, na = c("NA", "null", "string"), collapse = TRUE, dataframe = c("rows", "columns", "values"), complex = "string", oldna = NULL, rownames = NULL, keep_vec_names = FALSE, indent = NA_integer_, no_dots = FALSE, ...) {
+setMethod("asJSON", "data.frame", function(x, na = c("NA", "null", "string", "null_specials"), collapse = TRUE, dataframe = c("rows", "columns", "values"), complex = "string", oldna = NULL, rownames = NULL, keep_vec_names = FALSE, indent = NA_integer_, no_dots = FALSE, ...) {
   # Coerse pairlist if needed
   if (is.pairlist(x)) {
     x <- as.vector(x, mode = "list")

--- a/R/asJSON.logical.R
+++ b/R/asJSON.logical.R
@@ -1,4 +1,4 @@
-setMethod("asJSON", "logical", function(x, collapse = TRUE, na = c("null", "string", "NA"), auto_unbox = FALSE, keep_vec_names = FALSE, indent = NA_integer_, ...) {
+setMethod("asJSON", "logical", function(x, collapse = TRUE, na = c("null", "string", "NA", "null_specials"), auto_unbox = FALSE, keep_vec_names = FALSE, indent = NA_integer_, ...) {
   # shiny legacy exception
   if (isTRUE(keep_vec_names) && length(names(x))) {
     return(asJSON(as.list(x), collapse = collapse, na = na, auto_unbox = TRUE, ...))

--- a/R/asJSON.numeric.R
+++ b/R/asJSON.numeric.R
@@ -1,20 +1,25 @@
-asjson_numeric_fun <- function(x, digits = 5, use_signif = is(digits, "AsIs"), na = c("string", "null", "NA"), auto_unbox = FALSE, collapse = TRUE, keep_vec_names = FALSE, indent = NA_integer_, always_decimal = FALSE, ...) {
+asjson_numeric_fun <- function(x, digits = 5, use_signif = is(digits, "AsIs"), na = c("string", "null", "NA", "null_specials"), auto_unbox = FALSE, collapse = TRUE, keep_vec_names = FALSE, indent = NA_integer_, always_decimal = FALSE, ...) {
   # shiny legacy exception
   if (isTRUE(keep_vec_names) && length(names(x))) {
     return(asJSON(as.list(x), digits = digits, use_signif = use_signif, na = na, auto_unbox = TRUE, collapse = collapse, ...))
   }
 
   na <- match.arg(na)
+  na_specials <- identical(na, "null_specials")
+  if (na_specials) {
+    na <- "null"
+  }
+
   na_as_string <- switch(na, "string" = TRUE, "null" = FALSE, "NA" = NA, stop("invalid na_as_string"))
 
   # old R implementation
-  # tmp <- num_to_char_R(x, digits, na_as_string);
+  # tmp <- num_to_char_R(x, digits, na_as_string, na_specials);
 
   # fast C implementation
   tmp <- if (is(x, "integer64")) {
     integer64_to_char(x, na_as_string)
   } else {
-    num_to_char(x, digits, na_as_string, use_signif, always_decimal)
+    num_to_char(x, digits, na_as_string, use_signif, always_decimal, na_specials)
   }
 
   if (isTRUE(auto_unbox) && length(tmp) == 1) {

--- a/R/fromJSON.R
+++ b/R/fromJSON.R
@@ -33,7 +33,7 @@
 #' @param complex how to encode complex numbers: must be one of 'string' or 'list'
 #' @param raw how to encode raw objects: must be one of 'base64', 'hex' or 'mongo'
 #' @param null how to encode NULL values within a list: must be one of 'null' or 'list'
-#' @param na how to print NA values: must be one of 'null' or 'string'. Defaults are class specific
+#' @param na how to print NA values: must be one of 'null', 'string', or 'null_specials'. Defaults are class specific, and 'null_specials' only applies to 'numeric'
 #' @param auto_unbox automatically [unbox()] all atomic vectors of length 1. It is usually safer to avoid this and instead use the [unbox()] function to unbox individual elements.
 #'   An exception is that objects of class `AsIs` (i.e. wrapped in [I()]) are not automatically unboxed. This is a way to mark single values as length-1 arrays.
 #' @param digits max number of decimal digits to print for numeric values. Use [I()] to specify significant digits. Use `NA` for max precision.

--- a/R/num_to_char.R
+++ b/R/num_to_char.R
@@ -1,10 +1,14 @@
 #' @useDynLib jsonlite R_num_to_char
-num_to_char <- function(x, digits = NA, na_as_string = NA, use_signif = FALSE, always_decimal = FALSE) {
+num_to_char <- function(x, digits = NA, na_as_string = NA, use_signif = FALSE, always_decimal = FALSE, na_specials = FALSE) {
   if (is.na(digits)) digits <- NA_integer_
   stopifnot(is.numeric(x))
   stopifnot(is.numeric(digits))
   stopifnot(is.logical(na_as_string))
-  .Call(R_num_to_char, x, digits, na_as_string, use_signif, always_decimal)
+  stopifnot(is.logical(na_specials) && !is.na(na_specials))
+  if (na_specials) {
+    na_as_string <- FALSE
+  }
+  .Call(R_num_to_char, x, digits, na_as_string, use_signif, always_decimal, na_specials)
 }
 
 #' @useDynLib jsonlite R_integer64_to_char
@@ -12,7 +16,7 @@ integer64_to_char <- function(x, na_as_string = TRUE) {
   .Call(R_integer64_to_char, x, na_as_string)
 }
 
-num_to_char_R <- function(x, digits = NA, na_as_string = NA) {
+num_to_char_R <- function(x, digits = NA, na_as_string = NA, na_specials = FALSE) {
   if (is.na(digits)) digits <- NA_integer_
   stopifnot(is.numeric(x))
   stopifnot(is.numeric(digits))
@@ -25,13 +29,21 @@ num_to_char_R <- function(x, digits = NA, na_as_string = NA) {
   tmp <- as.character(x)
 
   # in numeric variables, NA, NaN, Inf are replaced by character strings
-  if (any(missings <- which(!is.finite(x)))) {
-    if (is.na(na_as_string)) {
-      tmp[missings] <- NA_character_
-    } else if (na_as_string) {
-      tmp[missings] <- wrapinquotes(x[missings])
-    } else {
-      tmp[missings] <- "null"
+  if (any(!is.finite(x))) {
+    isna <- which(is.na(x) & !is.nan(x))
+    isspec <- which(is.nan(x) | is.infinite(x))
+    if (length(isna) > 0L) {
+      tmp[isna] <-
+        if (is.na(na_as_string)) {
+          NA_character_
+        } else if (na_as_string) {
+          wrapinquotes(x[isna])
+        } else {
+          "null"
+        }
+    }
+    if (length(isspec)) {
+      tmp[isspec] <- if (na_specials) wrapinquotes(x[isspec]) else NA_character_
     }
   }
 

--- a/R/toJSON.R
+++ b/R/toJSON.R
@@ -9,7 +9,7 @@ toJSON <- function(
   complex = c("string", "list"),
   raw = c("base64", "hex", "mongo", "int", "js"),
   null = c("list", "null"),
-  na = c("null", "string"),
+  na = c("null", "string", "null_specials"),
   auto_unbox = FALSE,
   digits = 4,
   pretty = FALSE,

--- a/man/fromJSON.Rd
+++ b/man/fromJSON.Rd
@@ -26,7 +26,7 @@ toJSON(
   complex = c("string", "list"),
   raw = c("base64", "hex", "mongo", "int", "js"),
   null = c("list", "null"),
-  na = c("null", "string"),
+  na = c("null", "string", "null_specials"),
   auto_unbox = FALSE,
   digits = 4,
   pretty = FALSE,
@@ -65,7 +65,7 @@ toJSON(
 
 \item{null}{how to encode NULL values within a list: must be one of 'null' or 'list'}
 
-\item{na}{how to print NA values: must be one of 'null' or 'string'. Defaults are class specific}
+\item{na}{how to print NA values: must be one of 'null', 'string', or 'null_specials'. Defaults are class specific, and 'null_specials' only applies to 'numeric'}
 
 \item{auto_unbox}{automatically \code{\link[=unbox]{unbox()}} all atomic vectors of length 1. It is usually safer to avoid this and instead use the \code{\link[=unbox]{unbox()}} function to unbox individual elements.
 An exception is that objects of class \code{AsIs} (i.e. wrapped in \code{\link[=I]{I()}}) are not automatically unboxed. This is a way to mark single values as length-1 arrays.}

--- a/src/register.c
+++ b/src/register.c
@@ -21,7 +21,7 @@ extern SEXP C_transpose_list(SEXP, SEXP);
 extern SEXP R_base64_decode(SEXP);
 extern SEXP R_base64_encode(SEXP);
 extern SEXP R_integer64_to_char(SEXP, SEXP);
-extern SEXP R_num_to_char(SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP R_num_to_char(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_parse(SEXP, SEXP);
 extern SEXP R_parse_connection(SEXP, SEXP);
 extern SEXP R_reformat(SEXP, SEXP, SEXP);
@@ -44,7 +44,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"R_base64_decode",               (DL_FUNC) &R_base64_decode,               1},
   {"R_base64_encode",               (DL_FUNC) &R_base64_encode,               1},
   {"R_integer64_to_char",           (DL_FUNC) &R_integer64_to_char,           2},
-  {"R_num_to_char",                 (DL_FUNC) &R_num_to_char,                 5},
+  {"R_num_to_char",                 (DL_FUNC) &R_num_to_char,                 6},
   {"R_parse",                       (DL_FUNC) &R_parse,                       2},
   {"R_parse_connection",            (DL_FUNC) &R_parse_connection,            2},
   {"R_reformat",                    (DL_FUNC) &R_reformat,                    3},

--- a/tests/testthat/test-toJSON-numeric.R
+++ b/tests/testthat/test-toJSON-numeric.R
@@ -45,3 +45,11 @@ test_that("Force decimal works", {
   y2 <- fromJSON(toJSON(x1, digits = 9, always_decimal = TRUE), simplifyVector = FALSE)
   expect_identical(as.list(x1), y2)
 })
+
+test_that("Null specials works", {
+  x <- c(3, NA, Inf, -Inf, NaN)
+  expect_equal(toJSON(x), "[3,\"NA\",\"Inf\",\"-Inf\",\"NaN\"]")
+  expect_equal(toJSON(x, na = "string"), "[3,\"NA\",\"Inf\",\"-Inf\",\"NaN\"]")
+  expect_equal(toJSON(x, na = "null"), "[3,null,null,null,null]")
+  expect_equal(toJSON(x, na = "null_specials"), "[3,null,\"Inf\",\"-Inf\",\"NaN\"]")
+})

--- a/vignettes/json-mapping.Rnw.orig
+++ b/vignettes/json-mapping.Rnw.orig
@@ -231,6 +231,13 @@ toJSON(c(3.14, NA, NaN, 21, Inf, -Inf))
 toJSON(c(3.14, NA, NaN, 21, Inf, -Inf), na="null")
 @
 
+An alternative representation allows \texttt{NA} values to display as the literal \texttt{null} and \texttt{Inf}, \texttt{-Inf}, and \texttt{NaN} to be displayed as strings. While \JSON does not support the latter tokens as specific values, the consumer of the data needs to know how to interpret these strings, though they are handled intuitively in \R.
+
+<<>>=
+#Extended, non-default behavior
+toJSON(c(3.14, NA, NaN, 21, Inf, -Inf), na="null_specials")
+@
+
 \subsubsection{Special vector types: dates, times, factor, complex}
 
 Besides missing values, \JSON also lacks native support for some of the basic vector types in \R that frequently appear in data sets. These include vectors of class \texttt{Date}, \texttt{POSIXt} (timestamps), \texttt{factors} and \texttt{complex} vectors. By default, the \jsonlite package coerces these types to strings (using \texttt{as.character}):


### PR DESCRIPTION
I'm being optimistic that you'll be amenable to addressing #461. It's an opt-in addition to `na=` that defaults to unchanged legacy behavior.

Previous behavior:

```r
toJSON(c(3.14, NA, NaN, 21, Inf, -Inf))
# [3.14,"NA","NaN",21,"Inf","-Inf"] 
toJSON(c(3.14, NA, NaN, 21, Inf, -Inf), na = "null")
# [3.14,null,null,21,null,null] 
toJSON(c(3.14, NA, NaN, 21, Inf, -Inf), na = "string")
# [3.14,"NA","NaN",21,"Inf","-Inf"] 
```

With this patch:

```r
toJSON(c(3.14, NA, NaN, 21, Inf, -Inf))
# [3.14,"NA","NaN",21,"Inf","-Inf"] 
toJSON(c(3.14, NA, NaN, 21, Inf, -Inf), na = "null")
# [3.14,null,null,21,null,null] 
toJSON(c(3.14, NA, NaN, 21, Inf, -Inf), na = "string")
# [3.14,"NA","NaN",21,"Inf","-Inf"] 
toJSON(c(3.14, NA, NaN, 21, Inf, -Inf), na = "null_specials")
# [3.14,null,"NaN",21,"Inf","-Inf"] 
```

I added unit-tests to confirm this behavior. All other tests pass.

In full disclosure, there is a slight performance dip. In the C code I tried to be a bit more "unrolled" to mitigate this, but it's non-zero.

```r
set.seed(42)
n <- 10000
dat <- data.frame(lgl=sample(c(F,T,NA), size=n, replace=TRUE), int=sample(100L, size=n, replace=TRUE), num=runif(n=n), dat=sample(c(Sys.Date(), NA), size=n, replace=TRUE), psx=sample(c(Sys.time(), NA), size=n, replace=TRUE))
microbenchmark::microbenchmark(toJSON(dat), times=1000) # before this PR, after, and with "null_specials"
# Unit: milliseconds
#                             expr      min       lq     mean   median       uq      max neval
#               toJSON(dat) before 10.01105 10.26181 10.80194 10.32343 10.39608 78.23144  1000
#                toJSON(dat) after 11.40054 12.04596 12.74151 12.18012 12.41033 37.34489  1000
#  toJSON(dat, na="null_specials") 11.85302 12.49873 13.24990 12.62183 12.91810 39.65528  1000
```

The same method using `n <- 10`, a more modest comparison, not demonstrating a significant change.

```r
n <- 10
### ...
# Unit: microseconds
#                             expr     min       lq     mean   median      uq       max neval
#               toJSON(dat) before 183.762 197.8250 215.3376 206.3735 220.539  2900.955  1000
#                toJSON(dat) after 182.819 189.4815 213.9801 193.9505 215.209  9884.157  1000
#  toJSON(dat, na="null_specials") 176.710 194.6475 217.5185 198.7885 216.521 10203.055  1000
```

